### PR TITLE
feat: 마이페이지 구현

### DIFF
--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -12,6 +12,10 @@ const Header = () => {
         setIsPopupOpen(!isPopupOpen);
     };
 
+    const closeModal = () => {
+        setIsPopupOpen(false);
+    }
+
     return (
         <S.HeaderContainer>
             <S.Logo to="/">Logo</S.Logo>
@@ -23,14 +27,13 @@ const Header = () => {
                 </S.Nav>
                 <S.AuthButtons>
                     <S.UserButton onClick={togglePopup}>
-                        {isPopupOpen && <Mypage />}
                         <AiOutlineUser size={21} />
                     </S.UserButton>
                     <S.StyledLoginLink to="/login">로그인</S.StyledLoginLink>
                     <S.StyledLoginLink to="/signup">회원가입</S.StyledLoginLink>
                 </S.AuthButtons>
             </S.Container>
-            
+            {isPopupOpen && <Mypage closeModal={closeModal}/>}
         </S.HeaderContainer>
     );
 }

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -1,7 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
+import { AiOutlineUser } from "react-icons/ai";
+import Mypage from "./MyPage";
+
+
 import * as S from "./Styles/Header.styles";
 
 const Header = () => {
+    const [isPopupOpen, setIsPopupOpen] = useState(false);
+
+    const togglePopup = () => {
+        setIsPopupOpen(!isPopupOpen);
+    };
+
     return (
         <S.HeaderContainer>
             <S.Logo to="/">Logo</S.Logo>
@@ -12,6 +22,10 @@ const Header = () => {
                     <S.StyledNavLink>핫 플레이스</S.StyledNavLink>
                 </S.Nav>
                 <S.AuthButtons>
+                    <S.UserButton onClick={togglePopup}>
+                        {isPopupOpen && <Mypage />}
+                        <AiOutlineUser size={21} />
+                    </S.UserButton>
                     <S.StyledLoginLink to="/login">로그인</S.StyledLoginLink>
                     <S.StyledLoginLink to="/signup">회원가입</S.StyledLoginLink>
                 </S.AuthButtons>

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -26,9 +26,11 @@ const Header = () => {
                     <S.StyledNavLink>핫 플레이스</S.StyledNavLink>
                 </S.Nav>
                 <S.AuthButtons>
+                    {/* 로그인 기능 구현 후 uid를 통해 uid가 있으면 userbutton출력 */}
                     <S.UserButton onClick={togglePopup}>
                         <AiOutlineUser size={21} />
                     </S.UserButton>
+                    {/* uid가 없으면 로그인 회원가입 버튼 출력 */}
                     <S.StyledLoginLink to="/login">로그인</S.StyledLoginLink>
                     <S.StyledLoginLink to="/signup">회원가입</S.StyledLoginLink>
                 </S.AuthButtons>

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -1,8 +1,11 @@
+import { useState } from "react";
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "./Styles/Header.styles";
 
 
 const MyPage = ({ closeModal }) => {
+    const [selectedMenu, setSelectedMenu] = useState('mypage');
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             closeModal();
@@ -27,9 +30,48 @@ const MyPage = ({ closeModal }) => {
                     <S.Manners></S.Manners>
                 </S.UserPanel>
                 <S.SelectButton>
-                    <S.Button>마이페이지</S.Button>
-                    <S.Button>내 크루</S.Button>
+                    <S.Button
+                        onClick={() => setSelectedMenu('mypage')}
+                        className={selectedMenu === 'mypage' ? 'active': ''}
+                    >
+                        마이페이지
+                    </S.Button>
+                    <S.Button
+                        onClick={() => setSelectedMenu('crew')}
+                        className={selectedMenu === 'crew' ? 'active': ''}
+                    >
+                        내 크루
+                    </S.Button>
                 </S.SelectButton>
+                <S.ContentContainer>
+                    {selectedMenu === 'mypage' && (
+                        <S.MyPageContent>
+                            <p>마이페이지</p>
+                        </S.MyPageContent>
+                    )}
+                    {selectedMenu === 'crew' && (
+                        <S.CrewContent>
+                            <S.CrewList>
+                                {/* 크루는 최대 5개까지만 들어갈 수 있다. */}
+                                {[...Array(2)].map((_, index) => (
+                                    // 해당 크루 페이지로 이동할 수 있도록 추후 수정
+                                    <S.CrewItem key={index}>
+                                        <S.CrewImage/>
+                                        <S.CrewName>
+                                            크루명
+                                        </S.CrewName>
+                                        <S.CrewMember>
+                                            11/20
+                                        </S.CrewMember>
+                                    </S.CrewItem>
+                                ))}
+                            </S.CrewList>
+                            <S.CreateCrewButton to="/crewcreate" onClick={closeModal}>
+                                크루 생성
+                            </S.CreateCrewButton>
+                        </S.CrewContent>
+                    )}
+                </S.ContentContainer>
             </S.MyPage>
         </S.Panel>
     );

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -1,0 +1,10 @@
+import * as S from "./Styles/Header.styles";
+
+const MyPage = () => {
+    return(
+        <S.Panel>
+        </S.Panel>
+    );
+}
+
+export default MyPage;

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -1,11 +1,28 @@
+import { AiOutlineClose } from "react-icons/ai";
 import * as S from "./Styles/Header.styles";
 
-const MyPage = () => {
+
+const MyPage = ({ closeModal }) => {
+    const handlePanelClick = (e) => {
+        if(e.target === e.currentTarget){
+            closeModal();
+        }
+    }
+
+    const handleUserPanelClick = (e) => {
+        e.stopPropagation();
+    }
+
     return(
-        <S.Panel>
-            <S.MyPage>
-                <S.UserPanel>
+        <S.Panel onClick={handlePanelClick}>
+            <S.MyPage onClick={(e) => e.stopPropagation()}>
+                <S.UserPanel onClick={handleUserPanelClick}>
+                    <S.CloseButton onClick={closeModal}>
+                        <AiOutlineClose size={24}/>
+                    </S.CloseButton>
+                    {/* 프로필 이미지 */}
                     <S.ProfileImage/>
+                    {/* 사용자 닉네임 or 이름 */}
                     <S.Name>김매너</S.Name>
                     <S.Manners></S.Manners>
                 </S.UserPanel>

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -26,8 +26,11 @@ const MyPage = ({ closeModal }) => {
                     {/* 프로필 이미지 */}
                     <S.ProfileImage/>
                     {/* 사용자 닉네임 or 이름 */}
-                    <S.Name>김매너</S.Name>
-                    <S.Manners></S.Manners>
+                    <S.UserInfo>
+                        <S.Name>김매너</S.Name>
+                        {/* 매너점수를 score에 넣어 출력 */}
+                        <S.Manners score={25.1}/>
+                    </S.UserInfo>
                 </S.UserPanel>
                 <S.SelectButton>
                     <S.Button

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -3,7 +3,17 @@ import * as S from "./Styles/Header.styles";
 const MyPage = () => {
     return(
         <S.Panel>
-            <S.MyPage></S.MyPage>
+            <S.MyPage>
+                <S.UserPanel>
+                    <S.ProfileImage/>
+                    <S.Name>김매너</S.Name>
+                    <S.Manners></S.Manners>
+                </S.UserPanel>
+                <S.SelectButton>
+                    <S.Button>마이페이지</S.Button>
+                    <S.Button>내 크루</S.Button>
+                </S.SelectButton>
+            </S.MyPage>
         </S.Panel>
     );
 }

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -3,6 +3,7 @@ import * as S from "./Styles/Header.styles";
 const MyPage = () => {
     return(
         <S.Panel>
+            <S.MyPage></S.MyPage>
         </S.Panel>
     );
 }

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -62,7 +62,7 @@ export const AuthButtons = styled.div`
 export const UserButton = styled.button`
     border: none;
     background: none;
-    cursor:pointer;
+    cursor: pointer;
 `;
 
 
@@ -97,6 +97,18 @@ export const UserPanel = styled.div`
     align-items: center;
 `;
 
+export const CloseButton = styled.div`
+    background: none;
+    border: none;
+    position: absolute;
+    display: flex;
+    top: 10px;
+    right: 10px;
+    z-index:2;
+    color: #999;
+    cursor: pointer;
+`;
+
 export const ProfileImage = styled.img`
     width: 80px;
     height: 80px;
@@ -129,4 +141,5 @@ export const Button = styled.button`
     font-size: 14px;
     background: #222;
     color: #fff;
+    cursor: pointer;
 `

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -55,3 +55,24 @@ export const AuthButtons = styled.div`
     color: #000;
     padding: 10px 0;
 `;
+
+
+// Mypage.jsx
+
+export const UserButton = styled.button`
+    border: none;
+    background: none;
+    cursor:pointer;
+`;
+
+
+export const Panel = styled.div`
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    position: fixed;
+    display: flex;
+    top: 0;
+    left: 0;
+    z-index:1;
+`;

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -86,4 +86,47 @@ export const MyPage = styled.div`
     position: fixed;
     top: 60px;
     right: 400px;
+    flex-direction: column;
+`;
+
+export const UserPanel = styled.div`
+    width: 100%;
+    height:150px;
+    border:1px solid red;
+    display:flex;
+    align-items: center;
+`;
+
+export const ProfileImage = styled.img`
+    width: 80px;
+    height: 80px;
+    border-radius: 50%;
+    border: 1px solid red;
+    display: flex;
+    margin: 0 20px;
+`;
+
+export const Name = styled.p`
+    color: #fff;
+    font-size:22px;
+    font-weight: 600;
+    letter-spacing: 5px;
+    margin: 0 20px;
+`;
+
+export const Manners = styled.p`
+`;
+
+export const SelectButton = styled.div`
+    width: 100%:
+    border: 1px solid red;
+`;
+
+export const Button = styled.button`
+    width: 50%;
+    height: 60px;
+    border: none;
+    font-size: 14px;
+    background: #222;
+    color: #fff;
 `

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -78,8 +78,7 @@ export const Panel = styled.div`
 `;
 
 export const MyPage = styled.div`
-    width: 350px;
-    height: 450px;
+    width: 340px;
     background: #0b0b0b;
     border-radius: 15px;
     display: flex;
@@ -92,7 +91,6 @@ export const MyPage = styled.div`
 export const UserPanel = styled.div`
     width: 100%;
     height:150px;
-    border:1px solid red;
     display:flex;
     align-items: center;
 `;
@@ -113,7 +111,7 @@ export const ProfileImage = styled.img`
     width: 80px;
     height: 80px;
     border-radius: 50%;
-    border: 1px solid red;
+    border: 1px solid #fff;
     display: flex;
     margin: 0 20px;
 `;
@@ -130,8 +128,6 @@ export const Manners = styled.p`
 `;
 
 export const SelectButton = styled.div`
-    width: 100%:
-    border: 1px solid red;
 `;
 
 export const Button = styled.button`
@@ -142,4 +138,62 @@ export const Button = styled.button`
     background: #222;
     color: #fff;
     cursor: pointer;
+`;
+
+export const ContentContainer = styled.div`
+`;
+
+export const MyPageContent = styled.div`
+    height:250px;
+`;
+
+export const CrewContent = styled.div`
+`;
+
+export const CrewList = styled.div`
+    width:100%;
+`;
+
+export const CrewItem = styled.div`
+    width:100%;
+    height: 80px;
+    border-bottom:1px solid #797979;
+    position: relative;
+    display: flex;
+    align-items: center;
+    padding:0 35px;
+`;
+
+export const CreateCrewButton = styled(RouterNavLink)`
+    display: flex;
+    width: 100%;
+    height: 70px;
+    font-size: 15px;
+    text-decoration: none;
+    text-align: center;
+    align-items: center;
+    justify-content: center;
+    bottom: 0;
+    cursor: pointer;
+    color: #fff;
+`;
+
+export const CrewImage = styled.img`
+    width:45px;
+    height:45px;
+    border:1px solid #797979;
+    border-radius: 50%;
+`;
+
+export const CrewName = styled.p`
+    margin:13px;
+    font-weight: 600;
+`;
+
+export const CrewMember = styled.p`
+    font-size: 13px;
+    position: absolute;
+    display:flex;
+    bottom: 15px;
+    right: 30px;
 `

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -108,12 +108,21 @@ export const CloseButton = styled.div`
 `;
 
 export const ProfileImage = styled.img`
-    width: 80px;
-    height: 80px;
+    width: 90px;
+    height: 90px;
     border-radius: 50%;
     border: 1px solid #fff;
     display: flex;
-    margin: 0 20px;
+    margin-left:30px;
+`;
+
+export const UserInfo = styled.div`
+    width:50%;
+    height:100px;
+    margin:0 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 `;
 
 export const Name = styled.p`
@@ -121,10 +130,46 @@ export const Name = styled.p`
     font-size:22px;
     font-weight: 600;
     letter-spacing: 5px;
-    margin: 0 20px;
+    margin: 30px 20px;
 `;
 
 export const Manners = styled.p`
+    position: relative;
+    display: flex;
+    width:140px;
+    height:8px;
+    background: #EAEAEA;
+    border-radius:4px;
+    margin:0 20px;
+    
+    &::before {
+        content: '';
+        position: absolute;
+        height:100%;
+        width: ${props => props.score || 0}%;
+
+        background: ${props => {
+            if (props.score < 30) return '#FF666F'; //빨간색
+            if (props.score < 60) return '#FF9F3E'; //주황색
+            return '#75C1A7'; //초록색
+        }};
+        border-radius: 4px;
+        transition: width 0.3s ease;
+    }
+
+    &::after {
+        content: '${props => props.score || 0}℃';
+        position: absolute;
+        top:-20px;
+        right: 0;
+        color:${props => {
+            if (props.score < 30) return '#FF666F';
+            if (props.score < 60) return '#FF9F3E';
+            return '#75C1A7';
+        }};
+        font-size:13px;
+        font-wieght:600;
+    }
 `;
 
 export const SelectButton = styled.div`

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -76,3 +76,14 @@ export const Panel = styled.div`
     left: 0;
     z-index:1;
 `;
+
+export const MyPage = styled.div`
+    width: 350px;
+    height: 450px;
+    background: #0b0b0b;
+    border-radius: 15px;
+    display: flex;
+    position: fixed;
+    top: 60px;
+    right: 400px;
+`

--- a/src/pages/community/Community.jsx
+++ b/src/pages/community/Community.jsx
@@ -51,7 +51,7 @@ const Community = () => {
                         {/* 작성일은 현재 시간 - 작성 시간으로 계산 */}
                         <S.Date> · 1일</S.Date>
                     </S.UserInfoContainer>
-                    <S.ActivityImage to={`/Community/${post.id}`}/>
+                    <S.ActivityImage to={`/crew/crewCommunity/${post.id}`}/>
                     <S.PostInfoContainer>
                         <S.ButtonsContainer>
                             {/* uid를 통해 좋아요는 한번만 가능하도록 설정 */}
@@ -64,7 +64,7 @@ const Community = () => {
                         </S.ButtonsContainer>
                         <S.TextContainer>
                             <S.UserName>러닝초보123</S.UserName>
-                            <S.Title to={`/Community/${post.id}`}>{truncateTitle(post.title)}</S.Title>
+                            <S.Title to={`/crew/crewCommunity/${post.id}`}>{truncateTitle(post.title)}</S.Title>
                         </S.TextContainer>
                     </S.PostInfoContainer>
                 </S.ActivityCard>


### PR DESCRIPTION
## 변경사항
<br>
1. 마이페이지버튼과 크루버튼을 눌렀을 때 아래에 각각 다른창이 출력되도록 useState를 이용해 구현했습니다.

![image](https://github.com/user-attachments/assets/f823af7a-f618-4af1-8697-d38b186491c2)

<br>
[좌측 마이페이지 / 우측 크루페이지]
<div style="display: flex; gap: 10px;">
<img src="https://github.com/user-attachments/assets/7f4dd41c-ca09-44a6-b46b-0bc77d9fbd02" width="400" height="400"/>
<img src="https://github.com/user-attachments/assets/1829a1a2-ca72-447c-861d-d5c6ed83b21c" width="400" height="400"/>
</div>

<br>
2. CrweContent에는 height값을 주지 않아 crewItem이 추가되거나 삭제될때 MyPage의 전체 높이가<br>
자동으로 늘어나고 줄어들도록 구현했습니다.

![image](https://github.com/user-attachments/assets/bad03a6c-81de-4405-9bbd-81fddb159e14)

<br>
3. 매너온도기능 구현

![image](https://github.com/user-attachments/assets/a0b5ed03-2e11-4f67-8faa-529979304971)

<br>
- peusedo-elements를 사용해 가상요소 before, after를 만들었습니다.
<br>
- before는 매너 점수에 따른 width값을 가지고 0 ~ 29 빨간색 / 30 ~ 59 주황색 / 60 ~ 100 초록색으로 배경색이 변경될 수 있도록 구현했습니다.
<br>
- after는 매너 점수에 따른 점수를 출력하고 점수에 따라 글자색이 변경될 수 있도록 구현했습니다.
<br>

![image](https://github.com/user-attachments/assets/8902d11a-9646-4cc4-b630-ff30438a793c)
![image](https://github.com/user-attachments/assets/8541ee8a-c7ec-45e5-a865-0b74f5901ac7)
![image](https://github.com/user-attachments/assets/9888f0f1-f1e6-4ad2-ad09-63c1b53406a1)
