### PR TITLE
feat: notice페이지 구현 완료

### DIFF
--- a/src/pages/CrewMain/components/FloatingMenu.jsx
+++ b/src/pages/CrewMain/components/FloatingMenu.jsx
@@ -61,6 +61,11 @@ const MenuButton = styled.button`
     
     display: flex;
     justify-content: space-between;
+    &:hover{
+        cursor: pointer;
+        border-radius: 15px;
+        background-color: #DEDFE7;
+    }
     `;
 const MenuText = styled.div`
     font-size: 14px;

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -1,0 +1,130 @@
+import { useState } from "react";
+import styled from "styled-components";
+
+export default function AddNotice() {
+    const [isDeleted, setIsDeleted] = useState(false);
+
+    return(
+        <Wrapper>
+            <Container>
+                <MainContainer>
+                    <InputText placeholder="공지사항 입력"></InputText>
+                    <VoteContainer>
+                        <VoteBox shouldHide={isDeleted}>
+                            <VoteTitle>정모 참여 여부 투표</VoteTitle>
+                            <SelectBox>
+                                <SelectList>참여</SelectList>
+                                <SelectList>미참여</SelectList>
+                            </SelectBox>
+                        </VoteBox>
+                        <ButtonContainer>
+                            <VoteButton
+                                isDeleted={isDeleted}
+                                shouldHide={isDeleted}
+                                onClick={() => setIsDeleted(true)}
+                            >투표 삭제하기</VoteButton>
+                            {isDeleted && 
+                            <VoteButton 
+                                isDeleted={isDeleted}
+                                onClick={()=>setIsDeleted(false)}
+                            >투표 생성하기</VoteButton>}
+                        </ButtonContainer>
+                    </VoteContainer>
+                </MainContainer>
+                <SubContainer>
+                    <PostNotice>공지 생성</PostNotice>
+                </SubContainer>
+            </Container>
+        </Wrapper>
+    );
+}
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 30px;
+    margin-bottom: 100px;
+`;
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+        
+    margin-top: 30px;
+    margin-bottom: 100px;
+    width: 768px; 
+    height: 370px;
+    background-color: white;
+    border: 1px solid #DEDFE7;
+    border-radius: 15px;
+`;
+const MainContainer = styled.div`
+    display: flex;
+    
+`;
+const VoteContainer = styled.div`
+    margin: 50px 30px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    `;
+const VoteBox = styled.div`
+    width: 200px;
+    margin-bottom: 20px;
+    /* height: 160px; */
+    background-color: white;
+    border: 1px solid #F0F0F0;
+    border-radius: 5px;
+    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
+`;
+const VoteTitle = styled.ul`
+`;
+const SelectBox = styled.div`
+`;
+const SelectList = styled.li`
+    margin: 10px;
+    padding: 5px;
+    padding-left: 10px;
+    font-size: 15px;
+    list-style-type: none;
+    border: 1px solid #D4E3FB;
+    border-radius: 10px;
+`;
+const ButtonContainer = styled.div`
+`;
+const VoteButton = styled.button`
+    width: 200px;
+    padding: 10px;
+    border: none;
+    border-radius: 10px;
+    background-color: #F0F0F0;
+    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
+    color: ${props => props.isDeleted ? "black" : "red"};
+`;
+const InputText = styled.textarea`
+    margin: 40px 0px 20px 40px;
+    padding: 20px;
+    width: 420px;
+    height: 200px;
+    resize: none;
+    background-color: #F0F0F0;
+    border: none;
+    border-radius: 15px;
+`;
+const SubContainer = styled.div`
+    display: flex;
+    justify-content: center;
+`;
+const PostNotice = styled.button`
+    padding: 10px;
+    width: 15%;
+    color: white;
+    border: none;
+    border-radius: 30px;
+    background-color: #4B44B6;
+    &:hover{
+        background: #352EAE;
+        border: 1px solid white;
+    }
+`;

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -1,20 +1,43 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import styled from "styled-components";
 
 export default function AddNotice() {
     const [isDeleted, setIsDeleted] = useState(false);
+    const [voteInfo, setVoteInfo] = useState({});
+    const [notice, setNotice] = useState("");
+
+    // voteInfo 직접 수정 기능 만들기
+    useEffect(()=>{
+        const initialVoteInfo = {
+            title: "정모 참여 여부 투표",
+            selectList: ["참여", "미참여"]
+        }
+        setVoteInfo(initialVoteInfo);
+    },[]);
+
+    const handleNotice = (e) => setNotice(e.target.value);
+
+    const handleSubmit = ()=>{
+        console.log("공지내용:",notice);
+        console.log("voteTitle: ",voteInfo.title);
+        console.log("voteList: ",voteInfo.selectList);
+    }
 
     return(
         <Wrapper>
             <Container>
                 <MainContainer>
-                    <InputText placeholder="공지사항 입력"></InputText>
+                    <InputText 
+                        placeholder="공지사항 입력"
+                        onChange={handleNotice}
+                    />
                     <VoteContainer>
                         <VoteBox shouldHide={isDeleted}>
-                            <VoteTitle>정모 참여 여부 투표</VoteTitle>
+                            <VoteTitle>{voteInfo.title}</VoteTitle>
                             <SelectBox>
-                                <SelectList>참여</SelectList>
-                                <SelectList>미참여</SelectList>
+                                {voteInfo.selectList?.map((list, index)=>(
+                                    <SelectList key={index}>{list}</SelectList>
+                                ))}
                             </SelectBox>
                         </VoteBox>
                         <ButtonContainer>
@@ -32,7 +55,7 @@ export default function AddNotice() {
                     </VoteContainer>
                 </MainContainer>
                 <SubContainer>
-                    <PostNotice>공지 생성</PostNotice>
+                    <PostNotice onClick={handleSubmit}>공지 생성</PostNotice>
                 </SubContainer>
             </Container>
         </Wrapper>

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -18,9 +18,26 @@ export default function AddNotice() {
     const handleNotice = (e) => setNotice(e.target.value);
 
     const handleSubmit = ()=>{
+        const now = new Date();
+        const year = now.getFullYear();  // 현재 년도
+        const month = now.getMonth() + 1;  // 월 (0부터 시작하므로 +1)
+        const day = now.getDate();  // 일
+        const hours = now.getHours();  // 시
+        const minutes = now.getMinutes();  // 분
+        const dayOfWeek = now.getDay();  // 요일 번호 (0-6)
+
+        // 요일 배열, 인덱스 0부터 일요일, 월요일, ..., 토요일
+        const days = ["일", "월", "화", "수", "목", "금", "토"];
+        // 2024.12.14 (토) 같은 형식
+        const formatDate = `${year}.${month.toString().padStart(2, '0')}.${day.toString().padStart(2, '0')} (${days[dayOfWeek]})`;
+        // 17:03 같은 형식
+        const formatTime = `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+       
         console.log("공지내용:",notice);
         console.log("voteTitle: ",voteInfo.title);
         console.log("voteList: ",voteInfo.selectList);
+        console.log("날짜: ",formatDate);
+        console.log("시간: ",formatTime);
     }
 
     return(

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import styled from "styled-components";
+import * as S from "../Styles/Notice.styles";
 
 export default function AddNotice() {
     const [isDeleted, setIsDeleted] = useState(false);
@@ -41,130 +41,41 @@ export default function AddNotice() {
     }
 
     return(
-        <Wrapper>
-            <Container>
-                <MainContainer>
-                    <InputText 
+        <S.Wrapper>
+            <S.Container>
+                <S.MainContainer>
+                    <S.InputText 
                         placeholder="공지사항 입력"
                         onChange={handleNotice}
                     />
-                    <VoteContainer>
-                        <VoteBox shouldHide={isDeleted}>
-                            <VoteTitle>{voteInfo.title}</VoteTitle>
-                            <SelectBox>
+                    <S.VoteContainer>
+                        <S.VoteBox shouldHide={isDeleted}>
+                            <S.VoteTitle>{voteInfo.title}</S.VoteTitle>
+                            <S.SelectBox>
                                 {voteInfo.selectList?.map((list, index)=>(
-                                    <SelectList key={index}>{list}</SelectList>
+                                    <S.SelectList key={index}>{list}</S.SelectList>
                                 ))}
-                            </SelectBox>
-                        </VoteBox>
-                        <ButtonContainer>
-                            <VoteButton
+                            </S.SelectBox>
+                        </S.VoteBox>
+                        <S.ButtonContainer>
+                            <S.VoteButton
                                 isDeleted={isDeleted}
                                 shouldHide={isDeleted}
                                 onClick={() => setIsDeleted(true)}
-                            >투표 삭제하기</VoteButton>
+                            >투표 삭제하기</S.VoteButton>
                             {isDeleted && 
-                            <VoteButton 
+                            <S.VoteButton 
                                 isDeleted={isDeleted}
                                 onClick={()=>setIsDeleted(false)}
-                            >투표 생성하기</VoteButton>}
-                        </ButtonContainer>
-                    </VoteContainer>
-                </MainContainer>
-                <SubContainer>
-                    <PostNotice onClick={handleSubmit}>공지 생성</PostNotice>
-                </SubContainer>
-            </Container>
-        </Wrapper>
+                            >투표 생성하기</S.VoteButton>}
+                        </S.ButtonContainer>
+                    </S.VoteContainer>
+                </S.MainContainer>
+                <S.SubContainer>
+                    <S.PostNotice onClick={handleSubmit}>공지 생성</S.PostNotice>
+                </S.SubContainer>
+            </S.Container>
+        </S.Wrapper>
     );
 }
 
-const Wrapper = styled.div`
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: center;
-    margin-top: 30px;
-    margin-bottom: 100px;
-`;
-const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-        
-    margin-top: 30px;
-    margin-bottom: 100px;
-    width: 768px; 
-    height: 370px;
-    background-color: white;
-    border: 1px solid #DEDFE7;
-    border-radius: 15px;
-`;
-const MainContainer = styled.div`
-    display: flex;
-    
-`;
-const VoteContainer = styled.div`
-    margin: 50px 30px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    `;
-const VoteBox = styled.div`
-    width: 200px;
-    margin-bottom: 20px;
-    /* height: 160px; */
-    background-color: white;
-    border: 1px solid #F0F0F0;
-    border-radius: 5px;
-    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
-`;
-const VoteTitle = styled.ul`
-`;
-const SelectBox = styled.div`
-`;
-const SelectList = styled.li`
-    margin: 10px;
-    padding: 5px;
-    padding-left: 10px;
-    font-size: 15px;
-    list-style-type: none;
-    border: 1px solid #D4E3FB;
-    border-radius: 10px;
-`;
-const ButtonContainer = styled.div`
-`;
-const VoteButton = styled.button`
-    width: 200px;
-    padding: 10px;
-    border: none;
-    border-radius: 10px;
-    background-color: #F0F0F0;
-    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
-    color: ${props => props.isDeleted ? "black" : "red"};
-`;
-const InputText = styled.textarea`
-    margin: 40px 0px 20px 40px;
-    padding: 20px;
-    width: 420px;
-    height: 200px;
-    resize: none;
-    background-color: #F0F0F0;
-    border: none;
-    border-radius: 15px;
-`;
-const SubContainer = styled.div`
-    display: flex;
-    justify-content: center;
-`;
-const PostNotice = styled.button`
-    padding: 10px;
-    width: 15%;
-    color: white;
-    border: none;
-    border-radius: 30px;
-    background-color: #4B44B6;
-    &:hover{
-        background: #352EAE;
-        border: 1px solid white;
-    }
-`;

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -4,42 +4,68 @@ import { BsThreeDotsVertical } from "react-icons/bs";
 import { useState } from "react";
 
 // user정보도 받아오기 (이름, 포지션)
-export default function NoticeList({notices, togglePin}) {
+export default function NoticeList({notices, togglePin, toggleMenu}) {
     const [isManager, setIsManager] = useState(true);
 
-    const handlePin = (id)=> {
-        togglePin(id);
+    const handlePin = (id)=> togglePin(id);
+    const handleMenu = (id) => toggleMenu(id);
+
+    const handleUpdate = (id)=>{
+        // 수정페이지 이동(notice.id에 맞는)
+        console.log("수정: ", id);
+    }
+    const handleDelete = (id)=>{
+        // 삭제페이지 이동(notice.id에 맞는) => 경고창 띄워야함
+        console.log("삭제: ", id);
     }
 
     return(
         <Wrapper>
             {notices.map((notice)=>(
-                <Container key={notice.id}>
-                    <TopContainer>
-                        <UserInfoContainer>
-                            <Profile>
-                                <ProfileImage/>
-                                <ProfileText>
-                                    <UserPosition>관리자</UserPosition>
-                                    <UserName>러닝초보123</UserName>
-                                </ProfileText>
-                                <Date>{notice.date}<br/>{notice.time}</Date>
-                            </Profile>
-                        </UserInfoContainer>
+                <>
+                    <SubContainer key={notice.id}>
+                        {notice.isOpenedMenu && 
+                            <SubMenu>
+                                <MenuItem onClick={()=>handleUpdate(notice.id)}>수정</MenuItem>
+                                <MenuItem onClick={()=>handleDelete(notice.id)}>삭제</MenuItem>
+                            </SubMenu>
+                        }
+                    </SubContainer>
+                    <Container key={notice.id}>
+                        <TopContainer>
+                            <UserInfoContainer>
+                                <Profile>
+                                    <ProfileImage/>
+                                    <ProfileText>
+                                        <UserPosition>관리자</UserPosition>
+                                        <UserName>러닝초보123</UserName>
+                                    </ProfileText>
+                                    <Date>{notice.date}<br/>{notice.time}</Date>
+                                </Profile>
+                            </UserInfoContainer>
 
-                        {/* 관리자만 보이도록 */}
-                        {/* 버튼 기능 추가하기 */}
-                        <SettingContainer>
-                            <BsPinAngleFill 
+                            {/* 관리자만 보이도록 */}
+                            {/* 버튼 기능 추가하기 */}
+                            <SettingContainer>
+                                <BsPinAngleFill 
+                                    size={20}
+                                    color={notice.isPinned ? "#000000" : "#929292"}
+                                    onClick={()=>handlePin(notice.id)}
+                                />
+                                {isManager && 
+                                <StyledBsThreeDotsVertical
                                 size={20}
-                                color={notice.isPinned ? "#000000" : "#929292"}
-                                onClick={()=>handlePin(notice.id)}
-                            />
-                            {isManager && <BsThreeDotsVertical size={20} color="#929292"/>}
-                        </SettingContainer>
-                    </TopContainer>
-                    <NoticeContainer>{notice.content}</NoticeContainer>
-                </Container>
+                                onClick={()=>handleMenu(notice.id)}
+                                />}
+                            </SettingContainer>
+                        </TopContainer>
+                        <NoticeContainer>
+                            {notice.content.split('\n').map((item)=>(
+                                <div>{item}<br/></div>
+                            ))}
+                        </NoticeContainer>
+                    </Container>
+                </>
             ))}
         </Wrapper>
     );
@@ -59,35 +85,35 @@ const Container = styled.div`
 const TopContainer = styled.div`
     display: flex;
     justify-content: space-around;
-`;
+    `;
 const UserInfoContainer = styled.div`
     width: 100%;
-`;
+    `;
 const Profile = styled.div`
     display: flex;
     align-items: center;
     margin: 20px;
-`;
+    `;
 const ProfileImage = styled.img`
     width: 40px;
     height: 40px;
     border-radius: 50%;
     border: 1px solid red;
     margin-right: 10px;
-`;
+    `;
 const ProfileText = styled.div`
     height:35px;
     display: flex;
     flex-direction: column;
     /* justify-content: center; */
     margin:0;
-`;
+    `;
 const UserPosition = styled.p`
     color:#4B44B6;
     font-size: 15px;
     font-weight: 600;
     margin: 0;
-`;
+    `;
 const UserName = styled.p`
     /* height:45px; */
     /* display: flex; */
@@ -96,20 +122,41 @@ const UserName = styled.p`
     color:#000;
     font-size: 15px;
     font-weight: 600;
-`;
+    `;
 const Date = styled.div`
     margin: 0 0 10px 10px;
     color: #666666;
     font-size: 13px;
-`
+    `
 const SettingContainer = styled.div`
+    position: relative;
     width: 10%;
     display: flex;
     justify-content: space-between;
     margin: 20px;
+    `;
+const StyledBsThreeDotsVertical = styled(BsThreeDotsVertical)`
+    color: #929292;
 `;
 
 const NoticeContainer = styled.div`
     margin: 10px 70px 40px 70px;
 `;
-const NoticeListItem = styled.div``;
+// const NoticeListItem = styled.div``;
+const SubContainer = styled.div`
+    position: absolute;
+    padding-left: 760px;
+`;
+const SubMenu = styled.div`
+    width: 80px;
+    background-color: white;
+    border: 1px solid #f0f0f0;
+`;
+
+const MenuItem = styled.div`
+    text-align: center;
+    padding: 8px 12px;
+    &:hover {
+        background-color: #f0f0f0;
+    }
+`;

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -6,7 +6,6 @@ import { useState } from "react";
 // user정보도 받아오기 (이름, 포지션)
 export default function NoticeList({notices, togglePin}) {
     const [isManager, setIsManager] = useState(true);
-    // const [isPinned, setIsPinned] = useState(false);
 
     const handlePin = (id)=> {
         togglePin(id);
@@ -24,7 +23,7 @@ export default function NoticeList({notices, togglePin}) {
                                     <UserPosition>관리자</UserPosition>
                                     <UserName>러닝초보123</UserName>
                                 </ProfileText>
-                                <Date>{notice.date}</Date>
+                                <Date>{notice.date}<br/>{notice.time}</Date>
                             </Profile>
                         </UserInfoContainer>
 
@@ -99,7 +98,7 @@ const UserName = styled.p`
     font-weight: 600;
 `;
 const Date = styled.div`
-    margin: 0 0 20px 10px;
+    margin: 0 0 10px 10px;
     color: #666666;
     font-size: 13px;
 `

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -1,0 +1,107 @@
+import styled from "styled-components";
+import { BsPinAngleFill } from "react-icons/bs";
+import { BsThreeDotsVertical } from "react-icons/bs";
+import { useState } from "react";
+
+// user정보도 받아오기 (이름, 포지션)
+export default function NoticeList({notices}) {
+    const [isManager, setIsManager] = useState(true);
+
+    return(
+        <Wrapper>
+            {notices.map((notice)=>(
+                <Container key={notice.id}>
+                    <TopContainer>
+                        <UserInfoContainer>
+                            <Profile>
+                                <ProfileImage/>
+                                <ProfileText>
+                                    <UserPosition>관리자</UserPosition>
+                                    <UserName>러닝초보123</UserName>
+                                </ProfileText>
+                                <Date>{notice.date}</Date>
+                            </Profile>
+                        </UserInfoContainer>
+
+                        {/* 관리자만 보이도록 */}
+                        {/* 버튼 기능 추가하기 */}
+                        <SettingContainer>
+                            <BsPinAngleFill size={20} color="#000000"/>
+                            {isManager && <BsThreeDotsVertical size={20} color="#929292"/>}
+                        </SettingContainer>
+                    </TopContainer>
+                    <NoticeContainer>{notice.content}</NoticeContainer>
+                </Container>
+            ))}
+        </Wrapper>
+    );
+}
+
+const Wrapper = styled.div`
+`;
+const Container = styled.div`
+    margin-top: 30px;
+    /* margin-bottom: 100px; */
+    width: 768px; 
+    /* height: 300px;     */
+    background-color: white;
+    border: 1px solid #DEDFE7;
+    border-radius: 15px;
+`;
+const TopContainer = styled.div`
+    display: flex;
+    justify-content: space-around;
+`;
+const UserInfoContainer = styled.div`
+    width: 100%;
+`;
+const Profile = styled.div`
+    display: flex;
+    align-items: center;
+    margin: 20px;
+`;
+const ProfileImage = styled.img`
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    border: 1px solid red;
+    margin-right: 10px;
+`;
+const ProfileText = styled.div`
+    height:35px;
+    display: flex;
+    flex-direction: column;
+    /* justify-content: center; */
+    margin:0;
+`;
+const UserPosition = styled.p`
+    color:#4B44B6;
+    font-size: 15px;
+    font-weight: 600;
+    margin: 0;
+`;
+const UserName = styled.p`
+    /* height:45px; */
+    /* display: flex; */
+    /* align-items: flex-end; */
+    margin:0px;
+    color:#000;
+    font-size: 15px;
+    font-weight: 600;
+`;
+const Date = styled.div`
+    margin: 0 0 20px 10px;
+    color: #666666;
+    font-size: 13px;
+`
+const SettingContainer = styled.div`
+    width: 10%;
+    display: flex;
+    justify-content: space-between;
+    margin: 20px;
+`;
+
+const NoticeContainer = styled.div`
+    margin: 10px 70px 40px 70px;
+`;
+const NoticeListItem = styled.div``;

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 // user정보도 받아오기 (이름, 포지션)
-export default function NoticeList({notices, togglePin, toggleMenu}) {
+export default function NoticeList({notices, togglePin, toggleMenu, setNotices}) {
     const navigate = useNavigate();
     const [isManager, setIsManager] = useState(true);
 
@@ -21,6 +21,10 @@ export default function NoticeList({notices, togglePin, toggleMenu}) {
     }
     const handleDelete = (id)=>{
         // 삭제페이지 이동(notice.id에 맞는) => 경고창 띄워야함
+        if (window.confirm("정말로 삭제하시겠습니까?")) {
+            // 공지 삭제 후 상태 업데이트
+            setNotices(currentNotices => currentNotices.filter(notice => notice.id !== id));
+        }
         console.log("삭제: ", id);
     }
 

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -56,9 +56,9 @@ export default function NoticeList({notices, togglePin, toggleMenu, setNotices})
                             {/* 관리자만 보이도록 */}
                             {/* 버튼 기능 추가하기 */}
                             <SettingContainer>
-                                <BsPinAngleFill 
+                                <StyledBsPinAngleFill 
                                     size={20}
-                                    color={notice.isPinned ? "#000000" : "#929292"}
+                                    isPinned={notice.isPinned}
                                     onClick={()=>handlePin(notice.id)}
                                 />
                                 {isManager && 
@@ -136,7 +136,7 @@ const Date = styled.div`
     margin: 0 0 10px 10px;
     color: #666666;
     font-size: 13px;
-    `
+    `;
 const SettingContainer = styled.div`
     position: relative;
     width: 10%;
@@ -144,8 +144,19 @@ const SettingContainer = styled.div`
     justify-content: space-between;
     margin: 20px;
     `;
+const StyledBsPinAngleFill = styled(BsPinAngleFill)`
+    color: ${props=> props.isPinned ? "#000000" : "#929292"};
+    &:hover{
+        color: black;
+        cursor: pointer;
+    }
+`;
 const StyledBsThreeDotsVertical = styled(BsThreeDotsVertical)`
     color: #929292;
+    &:hover{
+        color: black;
+        cursor: pointer;
+    }
 `;
 
 const NoticeContainer = styled.div`

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -2,17 +2,22 @@ import styled from "styled-components";
 import { BsPinAngleFill } from "react-icons/bs";
 import { BsThreeDotsVertical } from "react-icons/bs";
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 
 // user정보도 받아오기 (이름, 포지션)
 export default function NoticeList({notices, togglePin, toggleMenu}) {
+    const navigate = useNavigate();
     const [isManager, setIsManager] = useState(true);
 
     const handlePin = (id)=> togglePin(id);
     const handleMenu = (id) => toggleMenu(id);
 
-    const handleUpdate = (id)=>{
+    const handleUpdate = ({notice})=>{
         // 수정페이지 이동(notice.id에 맞는)
-        console.log("수정: ", id);
+        navigate(`/crew/updateNotice/${notice.id}`, {
+            state: {noticeData: notice}
+        });
+        console.log("수정: ", notice.id);
     }
     const handleDelete = (id)=>{
         // 삭제페이지 이동(notice.id에 맞는) => 경고창 띄워야함
@@ -26,7 +31,7 @@ export default function NoticeList({notices, togglePin, toggleMenu}) {
                     <SubContainer key={notice.id}>
                         {notice.isOpenedMenu && 
                             <SubMenu>
-                                <MenuItem onClick={()=>handleUpdate(notice.id)}>수정</MenuItem>
+                                <MenuItem onClick={()=>handleUpdate({notice})}>수정</MenuItem>
                                 <MenuItem onClick={()=>handleDelete(notice.id)}>삭제</MenuItem>
                             </SubMenu>
                         }

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -1,13 +1,14 @@
 import styled from "styled-components";
 import { BsPinAngleFill } from "react-icons/bs";
 import { BsThreeDotsVertical } from "react-icons/bs";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 // user정보도 받아오기 (이름, 포지션)
 export default function NoticeList({notices, togglePin, toggleMenu, setNotices}) {
     const navigate = useNavigate();
     const [isManager, setIsManager] = useState(true);
+    const menuRefs = useRef([]);
 
     const handlePin = (id)=> togglePin(id);
     const handleMenu = (id) => toggleMenu(id);
@@ -17,7 +18,7 @@ export default function NoticeList({notices, togglePin, toggleMenu, setNotices})
         navigate(`/crew/updateNotice/${notice.id}`, {
             state: {noticeData: notice}
         });
-        console.log("수정: ", notice.id);
+        // console.log("수정: ", notice.id);
     }
     const handleDelete = (id)=>{
         // 삭제페이지 이동(notice.id에 맞는) => 경고창 띄워야함
@@ -25,16 +26,28 @@ export default function NoticeList({notices, togglePin, toggleMenu, setNotices})
             // 공지 삭제 후 상태 업데이트
             setNotices(currentNotices => currentNotices.filter(notice => notice.id !== id));
         }
-        console.log("삭제: ", id);
+        // console.log("삭제: ", id);
     }
+    // 메뉴 열린 상태에서 외부영역 클릭 시 닫힘
+    useEffect(() => {
+        function handleClickOutside(e) {
+            if (notices.some((notice, index) => notice.isOpenedMenu && menuRefs.current[index] && !menuRefs.current[index].contains(e.target))) {
+                setNotices(notices.map(notice => ({...notice, isOpenedMenu: false})));
+            }   
+        }
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, [notices]);
 
     return(
         <Wrapper>
-            {notices.map((notice)=>(
+            {notices.map((notice, index)=>(
                 <>
                     <SubContainer key={notice.id}>
                         {notice.isOpenedMenu && 
-                            <SubMenu>
+                            <SubMenu ref={el => menuRefs.current[index] = el}>
                                 <MenuItem onClick={()=>handleUpdate({notice})}>수정</MenuItem>
                                 <MenuItem onClick={()=>handleDelete(notice.id)}>삭제</MenuItem>
                             </SubMenu>

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -4,8 +4,13 @@ import { BsThreeDotsVertical } from "react-icons/bs";
 import { useState } from "react";
 
 // user정보도 받아오기 (이름, 포지션)
-export default function NoticeList({notices}) {
+export default function NoticeList({notices, togglePin}) {
     const [isManager, setIsManager] = useState(true);
+    // const [isPinned, setIsPinned] = useState(false);
+
+    const handlePin = (id)=> {
+        togglePin(id);
+    }
 
     return(
         <Wrapper>
@@ -26,7 +31,11 @@ export default function NoticeList({notices}) {
                         {/* 관리자만 보이도록 */}
                         {/* 버튼 기능 추가하기 */}
                         <SettingContainer>
-                            <BsPinAngleFill size={20} color="#000000"/>
+                            <BsPinAngleFill 
+                                size={20}
+                                color={notice.isPinned ? "#000000" : "#929292"}
+                                onClick={()=>handlePin(notice.id)}
+                            />
                             {isManager && <BsThreeDotsVertical size={20} color="#929292"/>}
                         </SettingContainer>
                     </TopContainer>

--- a/src/pages/CrewNotice/Components/UpdateNotice.jsx
+++ b/src/pages/CrewNotice/Components/UpdateNotice.jsx
@@ -1,0 +1,75 @@
+import { useLocation } from "react-router-dom";
+import * as S from "../Styles/Notice.styles";
+import { useEffect, useState } from "react";
+
+export default function UpdateNotice() {
+    const location = useLocation();
+
+    // const [isDeleted, setIsDeleted] = useState(false);
+    // const [voteInfo, setVoteInfo] = useState({});
+    const [notice, setNotice] = useState('');
+    console.log(notice);
+    useEffect(() => {
+        // location.state가 정의되어 있고, 그 안에 noticeData 객체가 존재하는지를 확인하여 상태 설정
+        if (location.state && location.state.noticeData) {
+            setNotice(location.state.noticeData.content);
+        }
+        // // 다른 notice 선택으로 인해 location.state변하기 때문에 의존성 배열로 설정
+    }, [location.state]);
+
+
+    // // voteInfo 직접 수정 기능 만들기
+    // useEffect(()=>{
+    //     const initialVoteInfo = {
+    //         title: "정모 참여 여부 투표",
+    //         selectList: ["참여", "미참여"]
+    //     }
+    //     setVoteInfo(initialVoteInfo);
+    // },[]);
+
+    const handleNotice = (e) => setNotice(e.target.value);
+
+    const handleSubmit = ()=>{
+        console.log("수정된 공지내용:",notice);
+        // console.log("voteTitle: ",voteInfo.title);
+        // console.log("voteList: ",voteInfo.selectList);
+    }
+
+    return(
+        <S.Wrapper>
+            <S.Container>
+                <S.MainContainer>
+                    <S.InputText 
+                        value={notice}
+                        onChange={handleNotice}
+                    ></S.InputText>
+                    {/* <S.VoteContainer>
+                        <S.VoteBox shouldHide={isDeleted}>
+                            <S.VoteTitle>{voteInfo.title}</S.VoteTitle>
+                            <S.SelectBox>
+                                {voteInfo.selectList?.map((list, index)=>(
+                                    <S.SelectList key={index}>{list}</S.SelectList>
+                                ))}
+                            </S.SelectBox>
+                        </S.VoteBox>
+                        <S.ButtonContainer>
+                            <S.VoteButton
+                                isDeleted={isDeleted}
+                                shouldHide={isDeleted}
+                                onClick={() => setIsDeleted(true)}
+                            >투표 삭제하기</S.VoteButton>
+                            {isDeleted && 
+                            <S.VoteButton 
+                                isDeleted={isDeleted}
+                                onClick={()=>setIsDeleted(false)}
+                            >투표 생성하기</S.VoteButton>}
+                        </S.ButtonContainer>
+                    </S.VoteContainer> */}
+                </S.MainContainer>
+                <S.SubContainer>
+                    <S.PostNotice onClick={handleSubmit}>공지 수정</S.PostNotice>
+                </S.SubContainer>
+            </S.Container>
+        </S.Wrapper>
+    );
+}

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -77,9 +77,13 @@ const AddNoticeButton = styled.button`
     border: none;
     color: white;
     font-size: 15px;
-    background-color: #352EAE;
+    background-color: #4B44B6;
     border: 1px solid #DEDFE7;
     border-radius: 20px;
+    &:hover{
+        background-color: #352EAE;
+        cursor: pointer;
+    }
 `;
 const NoticeContainer = styled.div`
     display: flex;

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -2,15 +2,15 @@ import styled from "styled-components";
 import NoticeList from "./Components/NoticeList";
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import AddNotice from "./Components/AddNotice";
 
 export default function CrewNotice() {
     const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
+    const [isOpenedMenu, setIsOpenedMenu] = useState(false);
     const initialNotices = [
-        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "16:00", isPinned: false },
-        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "13:00", isPinned: false },
-        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (목)", time: "03:00", isPinned: false }
+        { id: 1, content: "첫 번째 공지사항 내용입니다.\ndd", date: "2024.12.10 (화)", time: "12:00", isPinned: false, isOpenedMenu: false },
+        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "13:00", isPinned: false, isOpenedMenu: false },
+        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (목)", time: "03:00", isPinned: false, isOpenedMenu: false }
     ];
     
     useEffect(()=>{
@@ -34,14 +34,20 @@ export default function CrewNotice() {
     };
     useEffect(() => {
         setNotices(currentNotices => sortNotices([...currentNotices]));
-    }, [notices]);
+    }, []);
     
     // 경로 추가하기 
     const linktoAddNotice = () => navigate('/crew/crewNotice/addNotice');
     
     const togglePin = (id) => {
-        setNotices(notices.map(notice => 
-            notice.id === id ? {...notice, isPinned: !notice.isPinned} : notice
+        setNotices(sortNotices(notices.map(notice => 
+            notice.id === id ? {...notice, isPinned: !notice.isPinned} : notice)
+        ));
+        console.log(notices);
+    };
+    const toggleMenu = (id)=>{
+        setNotices(notices.map(notice=>
+            notice.id === id ? {...notice, isOpenedMenu: !notice.isOpenedMenu} : notice
         ));
     };
     return(
@@ -50,7 +56,11 @@ export default function CrewNotice() {
             <AddNoticeButton onClick={linktoAddNotice} >+ 공지추가</AddNoticeButton>
             {/* 무한스크롤 적용해야 함 */}
             <NoticeContainer>
-                <NoticeList notices={notices} togglePin={togglePin}/>
+                <NoticeList 
+                    notices={notices}
+                    togglePin={togglePin}
+                    toggleMenu={toggleMenu}
+                />
             </NoticeContainer>
         </Wrapper>
     );

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -37,7 +37,7 @@ export default function CrewNotice() {
     }, []);
     
     // 경로 추가하기 
-    const linktoAddNotice = () => navigate('/crew/crewNotice/addNotice');
+    const linktoAddNotice = () => navigate('/crew/addNotice');
     
     const togglePin = (id) => {
         setNotices(sortNotices(notices.map(notice => 

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -1,8 +1,11 @@
 import styled from "styled-components";
 import NoticeList from "./Components/NoticeList";
 import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import AddNotice from "./Components/AddNotice";
 
 export default function CrewNotice() {
+    const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
     const initialNotices = [
         { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" },
@@ -14,15 +17,37 @@ export default function CrewNotice() {
         setNotices(initialNotices);
     },[]);
 
+    // 경로 추가하기 
+    const linktoAddNotice = () => navigate('/crew/crewNotice/addNotice');
+
     return(
         <Wrapper>
-            {/* 무한스크롤 적용해야함 */}
-            <NoticeList notices={notices}/>
+            {/* userid 받아서 관리자만 보이도록 수정해야 함 */}
+            <AddNoticeButton onClick={linktoAddNotice} >+ 공지추가</AddNoticeButton>
+            {/* 무한스크롤 적용해야 함 */}
+            <NoticeContainer>
+                <NoticeList notices={notices}/>
+            </NoticeContainer>
         </Wrapper>
     );
 }
 
 const Wrapper = styled.div`
+`;
+const AddNoticeButton = styled.button`
+    position: fixed;
+    top: 190px;
+    width: 150px;
+    margin-left: 60px;
+    padding: 10px;
+    border: none;
+    color: white;
+    font-size: 15px;
+    background-color: #352EAE;
+    border: 1px solid #DEDFE7;
+    border-radius: 20px;
+`;
+const NoticeContainer = styled.div`
     display: flex;
     flex-direction: column;
     justify-content: center;

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -6,7 +6,6 @@ import { useNavigate } from "react-router-dom";
 export default function CrewNotice() {
     const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
-    const [isOpenedMenu, setIsOpenedMenu] = useState(false);
     const initialNotices = [
         { id: 1, content: "첫 번째 공지사항 내용입니다.\ndd", date: "2024.12.10 (화)", time: "12:00", isPinned: false, isOpenedMenu: false },
         { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "13:00", isPinned: false, isOpenedMenu: false },
@@ -60,6 +59,7 @@ export default function CrewNotice() {
                     notices={notices}
                     togglePin={togglePin}
                     toggleMenu={toggleMenu}
+                    setNotices={setNotices}
                 />
             </NoticeContainer>
         </Wrapper>

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+import NoticeList from "./Components/NoticeList";
+import { useEffect, useState } from "react";
+
+export default function CrewNotice() {
+    const [notices, setNotices] = useState([]);
+    const initialNotices = [
+        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" },
+        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" },
+        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" }
+    ];
+
+    useEffect(()=>{
+        setNotices(initialNotices);
+    },[]);
+
+    return(
+        <Wrapper>
+            {/* 무한스크롤 적용해야함 */}
+            <NoticeList notices={notices}/>
+        </Wrapper>
+    );
+}
+
+const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 30px;
+    margin-bottom: 100px;
+`;

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -12,19 +12,27 @@ export default function CrewNotice() {
         { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false },
         { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false }
     ];
+    
+    useEffect(()=>{
+        setNotices(initialNotices);
+    },[]);
+    
+    // 공지들 정렬
+    const sortNotices = (notices) => {
+        return notices.sort((a, b) => b.isPinned - a.isPinned);
+    };
+    useEffect(() => {
+        setNotices(currentNotices => sortNotices([...currentNotices]));
+    }, [notices]);
+    
+    // 경로 추가하기 
+    const linktoAddNotice = () => navigate('/crew/crewNotice/addNotice');
+    
     const togglePin = (id) => {
         setNotices(notices.map(notice => 
             notice.id === id ? {...notice, isPinned: !notice.isPinned} : notice
         ));
     };
-
-    useEffect(()=>{
-        setNotices(initialNotices);
-    },[]);
-
-    // 경로 추가하기 
-    const linktoAddNotice = () => navigate('/crew/crewNotice/addNotice');
-
     return(
         <Wrapper>
             {/* userid 받아서 관리자만 보이도록 수정해야 함 */}

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -8,10 +8,15 @@ export default function CrewNotice() {
     const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
     const initialNotices = [
-        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" },
-        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" },
-        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (수)" }
+        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false },
+        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false },
+        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false }
     ];
+    const togglePin = (id) => {
+        setNotices(notices.map(notice => 
+            notice.id === id ? {...notice, isPinned: !notice.isPinned} : notice
+        ));
+    };
 
     useEffect(()=>{
         setNotices(initialNotices);
@@ -26,7 +31,7 @@ export default function CrewNotice() {
             <AddNoticeButton onClick={linktoAddNotice} >+ 공지추가</AddNoticeButton>
             {/* 무한스크롤 적용해야 함 */}
             <NoticeContainer>
-                <NoticeList notices={notices}/>
+                <NoticeList notices={notices} togglePin={togglePin}/>
             </NoticeContainer>
         </Wrapper>
     );

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -8,9 +8,9 @@ export default function CrewNotice() {
     const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
     const initialNotices = [
-        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false },
-        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false },
-        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (수)", isPinned: false }
+        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.10", isPinned: false },
+        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.11", isPinned: false },
+        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12", isPinned: false }
     ];
     
     useEffect(()=>{
@@ -19,7 +19,14 @@ export default function CrewNotice() {
     
     // 공지들 정렬
     const sortNotices = (notices) => {
-        return notices.sort((a, b) => b.isPinned - a.isPinned);
+        return [...notices].sort((a, b) => {
+            if (b.isPinned !== a.isPinned) {
+                // isPinned == true인 notice를 상단에 배치
+                return b.isPinned - a.isPinned;
+            }
+            // isPinned 상태가 같은 경우 날짜 순으로 정렬
+            return a.date > b.date ? -1 : 1;
+        });
     };
     useEffect(() => {
         setNotices(currentNotices => sortNotices([...currentNotices]));

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -8,9 +8,9 @@ export default function CrewNotice() {
     const navigate = useNavigate();
     const [notices, setNotices] = useState([]);
     const initialNotices = [
-        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.10", isPinned: false },
-        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.11", isPinned: false },
-        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12", isPinned: false }
+        { id: 1, content: "첫 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "16:00", isPinned: false },
+        { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "13:00", isPinned: false },
+        { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (목)", time: "03:00", isPinned: false }
     ];
     
     useEffect(()=>{
@@ -25,6 +25,10 @@ export default function CrewNotice() {
                 return b.isPinned - a.isPinned;
             }
             // isPinned 상태가 같은 경우 날짜 순으로 정렬
+            if (a.date == b.date){
+                return a.time > b.time ? -1 : 1;
+            }
+            // -1(음수)가 하단으로
             return a.date > b.date ? -1 : 1;
         });
     };

--- a/src/pages/CrewNotice/Styles/Notice.styles.js
+++ b/src/pages/CrewNotice/Styles/Notice.styles.js
@@ -1,0 +1,91 @@
+import styled from "styled-components";
+
+export const Wrapper = styled.div`
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    margin-top: 30px;
+    margin-bottom: 100px;
+`;
+export const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+        
+    margin-top: 30px;
+    margin-bottom: 100px;
+    width: 768px; 
+    height: 370px;
+    background-color: white;
+    border: 1px solid #DEDFE7;
+    border-radius: 15px;
+`;
+export const MainContainer = styled.div`
+    display: flex;
+    
+`;
+export const VoteContainer = styled.div`
+    margin: 50px 30px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    `;
+export const VoteBox = styled.div`
+    width: 200px;
+    margin-bottom: 20px;
+    /* height: 160px; */
+    background-color: white;
+    border: 1px solid #F0F0F0;
+    border-radius: 5px;
+    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
+`;
+export const VoteTitle = styled.ul`
+`;
+export const SelectBox = styled.div`
+`;
+export const SelectList = styled.li`
+    margin: 10px;
+    padding: 5px;
+    padding-left: 10px;
+    font-size: 15px;
+    list-style-type: none;
+    border: 1px solid #D4E3FB;
+    border-radius: 10px;
+`;
+export const ButtonContainer = styled.div`
+`;
+export const VoteButton = styled.button`
+    width: 200px;
+    padding: 10px;
+    border: none;
+    border-radius: 10px;
+    background-color: #F0F0F0;
+    display: ${props => props.shouldHide ? 'none' : 'inline-block'};
+    color: ${props => props.isDeleted ? "black" : "red"};
+`;
+export const InputText = styled.textarea`
+    margin: 40px 0px 20px 40px;
+    padding: 20px;
+    width: 420px;
+    height: 200px;
+    resize: none;
+    background-color: #F0F0F0;
+    border: none;
+    border-radius: 15px;
+`;
+export const SubContainer = styled.div`
+    display: flex;
+    justify-content: center;
+`;
+export const PostNotice = styled.button`
+    padding: 10px;
+    width: 15%;
+    color: white;
+    border: none;
+    border-radius: 30px;
+    background-color: #4B44B6;
+    &:hover{
+        background: #352EAE;
+        border: 1px solid white;
+    }
+`;

--- a/src/pages/CrewNotice/Styles/Notice.styles.js
+++ b/src/pages/CrewNotice/Styles/Notice.styles.js
@@ -62,6 +62,10 @@ export const VoteButton = styled.button`
     background-color: #F0F0F0;
     display: ${props => props.shouldHide ? 'none' : 'inline-block'};
     color: ${props => props.isDeleted ? "black" : "red"};
+    &:hover{
+        background-color: #D8D8D8;
+        cursor: pointer;
+    }
 `;
 export const InputText = styled.textarea`
     margin: 40px 0px 20px 40px;
@@ -87,5 +91,6 @@ export const PostNotice = styled.button`
     &:hover{
         background: #352EAE;
         border: 1px solid white;
+        cursor: pointer;
     }
 `;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -8,6 +8,7 @@ import Login from "../pages/Login/Login";
 import Activities from "../pages/activities/Activities";
 import Details from "../pages/activities/components/Details";
 import Home from "../pages/home/Home";
+import CrewNotice from "../pages/CrewNotice/CrewNotice";
 
 
 const Router = () => {
@@ -22,6 +23,7 @@ const Router = () => {
                 <Route path="/crewcreate" element={<CrewCreate />} />
                 <Route path="/crew" element={<CrewMain />}>
                     <Route path="crewHome" element={<CrewHome />} />
+                    <Route path="crewNotice" element={<CrewNotice />} />
                 </Route>
             </Route>
         </Routes>

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -9,6 +9,7 @@ import Activities from "../pages/activities/Activities";
 import Details from "../pages/activities/components/Details";
 import Home from "../pages/home/Home";
 import CrewNotice from "../pages/CrewNotice/CrewNotice";
+import AddNotice from "../pages/CrewNotice/Components/AddNotice";
 
 
 const Router = () => {
@@ -24,6 +25,7 @@ const Router = () => {
                 <Route path="/crew" element={<CrewMain />}>
                     <Route path="crewHome" element={<CrewHome />} />
                     <Route path="crewNotice" element={<CrewNotice />} />
+                    <Route path="crewNotice/addNotice" element={<AddNotice />} />
                 </Route>
             </Route>
         </Routes>

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -10,6 +10,7 @@ import Details from "../pages/activities/components/Details";
 import Home from "../pages/home/Home";
 import CrewNotice from "../pages/CrewNotice/CrewNotice";
 import AddNotice from "../pages/CrewNotice/Components/AddNotice";
+import UpdateNotice from "../pages/CrewNotice/Components/UpdateNotice";
 
 
 const Router = () => {
@@ -25,7 +26,8 @@ const Router = () => {
                 <Route path="/crew" element={<CrewMain />}>
                     <Route path="crewHome" element={<CrewHome />} />
                     <Route path="crewNotice" element={<CrewNotice />} />
-                    <Route path="crewNotice/addNotice" element={<AddNotice />} />
+                    <Route path="addNotice" element={<AddNotice />} />
+                    <Route path="updateNotice/:noticeId" element={<UpdateNotice />} />
                 </Route>
             </Route>
         </Routes>


### PR DESCRIPTION
## 변경사항

https://github.com/user-attachments/assets/c0927b0a-2fc8-4c4c-b2eb-282d4a3965a0

- 공지 기본 정렬(작성 날짜 순에 따라 정렬)
- 공지 고정기능(여러 개 고정 시 옛날에 적은 공지가 아래쪽에 배치)
```jsx
    // 공지들 정렬
    const sortNotices = (notices) => {
        return [...notices].sort((a, b) => {
            if (b.isPinned !== a.isPinned) {
                // isPinned == true인 notice를 상단에 배치
                return b.isPinned - a.isPinned;
            }
            // isPinned 상태가 같은 경우 날짜 순으로 정렬
            if (a.date == b.date){
                return a.time > b.time ? -1 : 1;
            }
            // -1(음수)가 하단으로
            return a.date > b.date ? -1 : 1;
        });
    };
    useEffect(() => {
        setNotices(currentNotices => sortNotices([...currentNotices]));
    }, []);
```

- 공지 추가 페이지(투표 기능 추가/삭제 가능)
- 공지 설정 토글 버튼(수정/삭제) 외부 영역 선택 시 토글 닫힘 기능 => useRef 훅 사용했슴다
```jsx
// 메뉴 열린 상태에서 외부영역 클릭 시 닫힘
    useEffect(() => {
        function handleClickOutside(e) {
            if (notices.some((notice, index) => notice.isOpenedMenu && menuRefs.current[index] && !menuRefs.current[index].contains(e.target))) {
                setNotices(notices.map(notice => ({...notice, isOpenedMenu: false})));
            }   
        }
        document.addEventListener('mousedown', handleClickOutside);
        return () => {
            document.removeEventListener('mousedown', handleClickOutside);
        };
    }, [notices]);
```
- 공지 수정 페이지(useNavigate의 state속성, useLocation 훅을 사용하여 페이지 이동하며 notice 데이터 전달하도록 함)
- 공지 삭제 기능 (filter함수 사용)


## 보완할 점
- 공지 추가 페이지와 수정 페이지는 등록 시 변경사항 적용되도록 해야합니다.(공지 메인 페이지에 공지 리스트 업데이트 기능)
- 🚨 특정 공지 삭제 시 해당 공지의 설정 버튼이 사라지지 않는 버그 해결하기(영상 마지막에서 볼 수 있습니다)
- 공지 수정에서도 투표 추가/삭제 가능하도록 해야 함.
- 투표 커스텀 기능(정모 참여 여부 말고도 직접 설정 가능하도록)
- 투표 기능 구체화 -> 투표 기능 있는 공지 만들기
- 무한스크롤?기능
