### PR TITLE
Feat: 크루 이름 및 배너사진 설정 디자인 구현

### DIFF
--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -4,7 +4,7 @@ import * as S from "./Styles/Header.styles";
 
 
 const MyPage = ({ closeModal }) => {
-    const [selectedMenu, setSelectedMenu] = useState('mypage');
+    const [selectedMenu, setSelectedMenu] = useState('crew');
 
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -1,12 +1,27 @@
 import { useState } from "react";
 import { BsChevronRight } from "react-icons/bs";
+import Administrator from "./components/Administrator";
+import CrewActivity from "./components/CrewActivity";
+import CrewIntro from "./components/CrewIntro";
+import CrewMember from "./components/CrewMember";
+import CrewRule from "./components/CrewRule";
+import CrewSchedule from "./components/CrewSchedule";
+import Delete from "./components/Delete";
+import LeaderTransfer from "./components/LeaderTransfer";
 import SettingBanner from "./components/SettingBanner";
 import * as S from "./Styles/CrewSetting.styles";
 
 
 const CrewSetting = () => {
     const [isSettingBannerOpen, setIsSettingBannerOpen] = useState(false);
-
+    const [isCrewIntroOpen, setIsCrewIntroOpen] = useState(false);
+    const [isCrewMemberOpen, setIsCrewMemberOpen] = useState(false);
+    const [isCrewRuleOpen, setIsCrewRuleOpen] = useState(false);
+    const [isCrewActivityOpen, setIsCrewActivityOpen] = useState(false);
+    const [isCrewScheduleOpen, setIsCrewScheduleOpen] = useState(false);
+    const [isAdministratorOpen, setIsAdministratorOpen] = useState(false);
+    const [isLeaderTransferOpen, setIsLeaderTransferOpen] = useState(false);
+    const [isDeleteOpen, setIsDeleteOpen] = useState(false);
     return(
         <S.Container>
             <S.Setting>
@@ -22,7 +37,7 @@ const CrewSetting = () => {
                 </S.SubTitle>
                 <S.SubTitle>
                     <S.Title>크루 소개 설정</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsCrewIntroOpen(true)}><BsChevronRight/></S.Button>
                     {/* <S.Desc>크루 소개글 수정, 지역/주소/카테고리 설정</S.Desc> */}
                 </S.SubTitle>
                 <S.MainTitle>
@@ -30,11 +45,11 @@ const CrewSetting = () => {
                 </S.MainTitle>
                 <S.SubTitle>
                     <S.Title>크루 멤버수</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsCrewMemberOpen(true)}><BsChevronRight/></S.Button>
                 </S.SubTitle>
                 <S.SubTitle>
                     <S.Title>가입 조건 설정</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsCrewRuleOpen(true)}><BsChevronRight/></S.Button>
                     {/* 설정한 조건 출력 */}
                     {/* <S.Desc>성별 제한없음, 나이 제한없음</S.Desc> */}
                 </S.SubTitle>
@@ -43,14 +58,14 @@ const CrewSetting = () => {
                 </S.MainTitle>
                 <S.SubTitle>
                     <S.Title>멤버 탈퇴, 차단 설정</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsCrewActivityOpen(true)}><BsChevronRight/></S.Button>
                 </S.SubTitle>
                 <S.MainTitle>
                     <S.Title>크루 일정 관리</S.Title>
                 </S.MainTitle>
                 <S.SubTitle>
                     <S.Title>일정 설정</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsCrewScheduleOpen(true)}><BsChevronRight/></S.Button>
                     {/* <S.Desc>일정 권한 수정</S.Desc> */}
                 </S.SubTitle>
                 <S.MainTitle>
@@ -58,21 +73,61 @@ const CrewSetting = () => {
                 </S.MainTitle>
                 <S.SubTitle>
                     <S.Title>공동 관리자 관리</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsAdministratorOpen(true)}><BsChevronRight/></S.Button>
                 </S.SubTitle>
                 <S.SubTitle>
                     <S.Title>리더 위임</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsLeaderTransferOpen(true)}><BsChevronRight/></S.Button>
                 </S.SubTitle>
                 <S.MainTitle>
                     <S.Title style={{ color: 'red' }}>크루 삭제</S.Title>
-                    <S.Button><BsChevronRight/></S.Button>
+                    <S.Button onClick={() => setIsDeleteOpen(true)}><BsChevronRight/></S.Button>
                 </S.MainTitle>
             </S.Setting>
 
             {isSettingBannerOpen && (
-                <SettingBanner 
+                <SettingBanner
                     onClose={() => setIsSettingBannerOpen(false)}
+                />
+            )}
+            {isCrewIntroOpen && (
+                <CrewIntro
+                    onClose={() => setIsCrewIntroOpen(false)}
+                />
+            )}
+            {isCrewMemberOpen && (
+                <CrewMember
+                    onClose={() => setIsCrewMemberOpen(false)}
+                />
+            )}
+            {isCrewRuleOpen && (
+                <CrewRule
+                    onClose={() => setIsCrewRuleOpen(false)}
+                />
+            )}
+            {isCrewActivityOpen && (
+                <CrewActivity
+                    onClose={() => setIsCrewActivityOpen(false)}
+                />
+            )}
+            {isCrewScheduleOpen && (
+                <CrewSchedule
+                    onClose={() => setIsCrewScheduleOpen(false)}
+                />
+            )}
+            {isAdministratorOpen && (
+                <Administrator
+                    onClose={() => setIsAdministratorOpen(false)}
+                />
+            )}
+            {isLeaderTransferOpen && (
+                <LeaderTransfer
+                    onClose={() => setIsLeaderTransferOpen(false)}
+                />
+            )}
+            {isDeleteOpen && (
+                <Delete
+                    onClose={() => setIsDeleteOpen(false)}
                 />
             )}
         </S.Container>

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -1,0 +1,9 @@
+const CrewSetting = () => {
+    return(
+        <>
+            <div>CrewSetting</div>
+        </>
+    );
+}
+
+export default CrewSetting;

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -1,8 +1,81 @@
+import { useState } from "react";
+import { BsChevronRight } from "react-icons/bs";
+import SettingBanner from "./components/SettingBanner";
+import * as S from "./Styles/CrewSetting.styles";
+
+
 const CrewSetting = () => {
+    const [isSettingBannerOpen, setIsSettingBannerOpen] = useState(false);
+
     return(
-        <>
-            <div>CrewSetting</div>
-        </>
+        <S.Container>
+            <S.Setting>
+                <S.CrewName>
+                    <S.Title>초코러닝(초보자 코스 러닝)</S.Title>
+                </S.CrewName>
+                <S.MainTitle>
+                    <S.Title>크루 기본 정보 관리</S.Title>
+                </S.MainTitle>
+                <S.SubTitle>
+                    <S.Title>크루 이름 및 배너사진 설정</S.Title>
+                    <S.Button onClick={() => setIsSettingBannerOpen(true)}><BsChevronRight/></S.Button>
+                </S.SubTitle>
+                <S.SubTitle>
+                    <S.Title>크루 소개 설정</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                    {/* <S.Desc>크루 소개글 수정, 지역/주소/카테고리 설정</S.Desc> */}
+                </S.SubTitle>
+                <S.MainTitle>
+                    <S.Title>크루 가입 관리</S.Title>
+                </S.MainTitle>
+                <S.SubTitle>
+                    <S.Title>크루 멤버수</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                </S.SubTitle>
+                <S.SubTitle>
+                    <S.Title>가입 조건 설정</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                    {/* 설정한 조건 출력 */}
+                    {/* <S.Desc>성별 제한없음, 나이 제한없음</S.Desc> */}
+                </S.SubTitle>
+                <S.MainTitle>
+                    <S.Title>멤버 활동 관리</S.Title>
+                </S.MainTitle>
+                <S.SubTitle>
+                    <S.Title>멤버 탈퇴, 차단 설정</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                </S.SubTitle>
+                <S.MainTitle>
+                    <S.Title>크루 일정 관리</S.Title>
+                </S.MainTitle>
+                <S.SubTitle>
+                    <S.Title>일정 설정</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                    {/* <S.Desc>일정 권한 수정</S.Desc> */}
+                </S.SubTitle>
+                <S.MainTitle>
+                    <S.Title>리더, 공동 관리자 관리</S.Title>
+                </S.MainTitle>
+                <S.SubTitle>
+                    <S.Title>공동 관리자 관리</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                </S.SubTitle>
+                <S.SubTitle>
+                    <S.Title>리더 위임</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                </S.SubTitle>
+                <S.MainTitle>
+                    <S.Title style={{ color: 'red' }}>크루 삭제</S.Title>
+                    <S.Button><BsChevronRight/></S.Button>
+                </S.MainTitle>
+            </S.Setting>
+
+            {isSettingBannerOpen && (
+                <SettingBanner 
+                    onClose={() => setIsSettingBannerOpen(false)}
+                />
+            )}
+        </S.Container>
     );
 }
 

--- a/src/pages/CrewSetting/Styles/CrewSetting.styles.js
+++ b/src/pages/CrewSetting/Styles/CrewSetting.styles.js
@@ -1,0 +1,89 @@
+import styled from "styled-components";
+
+
+export const Container = styled.div`
+    width:1024px;
+    margin:100px auto;
+`;
+
+export const Setting = styled.div`
+    width:100%;
+    border:1px solid #DEDFE7;
+
+    & > p {
+        float: left;
+    }
+`;
+
+export const CrewName = styled.div`
+    width:100%;
+    height:55px;
+    display: flex;
+    align-items: center;
+    padding:0 30px;
+    font-size:20px;
+    background: #D7D5EF;
+`
+
+export const MainTitle = styled.div`
+    width:100%;
+    height:45px;
+    display: flex;
+    align-items: center;
+    padding-left: 45px;
+    padding-right: 30px;
+    font-size:15px;
+    border-top:1px solid #C3C4CF;
+`;
+
+export const SubTitle = styled.div`
+    width: 100%;
+    height: 45px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    font-size: 15px;
+    padding: 0 30px;
+    background: #DEDFE7;
+    border-top:1px solid #C3C4CF;
+`;
+
+export const Title = styled.p`
+    width:25%;
+`;
+
+export const Desc = styled.p`
+    display: flex;
+    color: #898989;
+`;
+
+export const Button = styled.button`
+    background: none;
+    border: none;
+    font-size: 15px;
+    cursor: pointer;
+    display: flex;
+    margin-left: auto;
+`;
+
+export const Panel = styled.div`
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    background-color: white;
+    padding: 20px;
+    border-radius: 8px;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
+    z-index: 1000;
+`;
+
+export const Overlay = styled.div`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: rgba(0, 0, 0, 0.5);
+    z-index: 999;
+`;

--- a/src/pages/CrewSetting/Styles/CrewSetting.styles.js
+++ b/src/pages/CrewSetting/Styles/CrewSetting.styles.js
@@ -66,24 +66,42 @@ export const Button = styled.button`
     margin-left: auto;
 `;
 
-export const Panel = styled.div`
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: white;
-    padding: 20px;
-    border-radius: 8px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-    z-index: 1000;
-`;
+// SettingBanner.jsx
 
-export const Overlay = styled.div`
+export const Panel = styled.div`
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
     position: fixed;
+    display: flex;
     top: 0;
     left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: rgba(0, 0, 0, 0.5);
-    z-index: 999;
+    z-index:1;
+`;
+
+export const BannerContainer = styled.div`
+    width:100%;
+    height:100%;
+    background-color: #D7D5EF;
+`;
+
+export const MyPage = styled.div`
+    width: 50%;
+    height: 50%;
+    background: #0b0b0b;
+    border-radius: 15px;
+    display: flex;
+    position: fixed;
+    top: 20%;
+    right: 25%;
+    flex-direction: column;
+`;
+
+export const CloseButton = styled.button`
+    background: none;
+    border: none;
+    font-size: 15px;
+    cursor: pointer;
+    display: flex;
+    margin-left: auto;
 `;

--- a/src/pages/CrewSetting/components/Administrator.jsx
+++ b/src/pages/CrewSetting/components/Administrator.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const Administrator = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>크루 관리자 관리</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default Administrator;

--- a/src/pages/CrewSetting/components/Administrator.jsx
+++ b/src/pages/CrewSetting/components/Administrator.jsx
@@ -1,6 +1,6 @@
+import { useEffect, useRef, useState } from "react";
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
-
 
 const Administrator = ({ onClose }) => {
     const handlePanelClick = (e) => {
@@ -9,16 +9,90 @@ const Administrator = ({ onClose }) => {
         }
     }
 
+    // 멤버 api를 불러와 리더, 관리자, 멤버를 비교
+    const members = Array.from({ length: 20 }, (_, index) => ({
+        id: index,
+        name: `김멤버`,
+        role: index === 0 ? '리더' : (index === 1 || index === 2) ? '관리자' : '멤버', // 리더, 관리자, 멤버 구분
+    }));
+
+    const [visibleMembers, setVisibleMembers] = useState(3);
+    const observerRef = useRef();
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if(entries[0].isIntersecting && visibleMembers < members.length){
+                    setVisibleMembers(prev => prev + 3);
+                }
+            },
+            { threshold: 0.5 }
+        );
+
+        if(observerRef.current){
+            observer.observe(observerRef.current);
+        }
+
+        return () => observer.disconnect();
+    }, [visibleMembers, members.length]);
+
+    // 멤버 정렬 함수
+    const sortMembers = (members) => {
+        const roleOrder = { '리더': 0, '관리자': 1, '멤버': 2 };
+        return [...members].sort((a, b) => roleOrder[a.role] - roleOrder[b.role]);
+    };
+
+    const sortedMembers = sortMembers(members);
+
     return (
         <S.Panel onClick={handlePanelClick}>
-            <S.MyPage onClick={(e) => e.stopPropagation()}>
-                <S.BannerContainer>
+            <S.BannerContainer onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: "560px",
+                    right: "35%",
+                }}
+            >
+                <S.DeleteContainer>
+                    <S.SettingTitle>
+                        공동 관리자 관리
+                    </S.SettingTitle>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 관리자 관리</h2>
-                </S.BannerContainer>
-            </S.MyPage>
+                </S.DeleteContainer>
+                <S.SettingContainer
+                    style={{
+                        maxHeight: "380px",
+                        overflow: "auto",
+                        msOverflowStyle: "none",
+                        scrollbarWidth: "none",
+                        margin: "20px 0",
+                        "&::-webkit-scrollbar": {
+                            display: "none"
+                        }
+                    }}
+                >
+                    {sortedMembers.slice(0, visibleMembers).map((member, index) => (
+                        <S.MemberSection key={index}>
+                            <S.ProfileImage />
+                            <S.Name>
+                                {member.name}
+                            </S.Name>
+                            <S.Role>{member.role}</S.Role>
+                            {member.role === '멤버' && (
+                                <S.AdminButton>관리자로 승격</S.AdminButton>
+                            )}
+                            {member.role === '관리자' && (
+                                <S.AdminButton>멤버로 강등</S.AdminButton>
+                            )}
+                        </S.MemberSection>
+                    ))}
+                    {visibleMembers < members.length && (
+                        <div ref={observerRef}>
+                        </div>
+                    )}
+                </S.SettingContainer>
+            </S.BannerContainer>
         </S.Panel>
     );
 };

--- a/src/pages/CrewSetting/components/CrewActivity.jsx
+++ b/src/pages/CrewSetting/components/CrewActivity.jsx
@@ -1,6 +1,6 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
-
+import { useState, useRef, useEffect } from "react";
 
 const CrewActivity = ({ onClose }) => {
     const handlePanelClick = (e) => {
@@ -9,16 +9,81 @@ const CrewActivity = ({ onClose }) => {
         }
     }
 
+    // 멤버 api를 불러와 리더와 멤버를 비교
+    // 리더외엔 탈퇴버튼 표시
+    const members = Array.from({ length: 20 }, (_, index) => ({
+        id: index,
+        name: `김멤버`,
+        role: index === 0 ? '리더' : '', // 첫 번째 멤버(index가 0)일 때만 '리더'로 설정
+    }));
+
+    const [visibleMembers, setVisibleMembers] = useState(3);
+    const observerRef = useRef();
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if(entries[0].isIntersecting && visibleMembers < members.length){
+                    setVisibleMembers(prev => prev + 3);
+                }
+            },
+            { threshold: 0.5 }
+        );
+
+        if(observerRef.current){
+            observer.observe(observerRef.current);
+        }
+
+        return () => observer.disconnect();
+    }, [visibleMembers, members.length]);
+
+
     return (
         <S.Panel onClick={handlePanelClick}>
-            <S.MyPage onClick={(e) => e.stopPropagation()}>
-                <S.BannerContainer>
+            <S.BannerContainer onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: "560px",
+                    right: "35%",
+                }}
+            >
+                <S.DeleteContainer>
+                    <S.SettingTitle>
+                        멤버 활동 관리
+                    </S.SettingTitle>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>멤버 활동 관리</h2>
-                </S.BannerContainer>
-            </S.MyPage>
+                </S.DeleteContainer>
+                <S.SettingContainer
+                    style={{
+                        maxHeight: "380px",
+                        overflow: "auto",
+                        msOverflowStyle: "none",
+                        scrollbarWidth: "none",
+                        margin: "20px 0",
+                        "&::-webkit-scrollbar": {
+                            display: "none"
+                        }
+                    }}
+                >
+                    {members.slice(0, visibleMembers).map((member, index) => (
+                        <S.MemberSection key={index}>
+                            <S.ProfileImage />
+                            <S.Name>
+                                {member.name}
+                            </S.Name>
+                            <S.Role>{member.role}</S.Role>
+                            {member.role !== '리더' && (
+                                <S.CrewButton>탈퇴</S.CrewButton>
+                            )}
+                        </S.MemberSection>
+                    ))}
+                    {visibleMembers < members.length && (
+                        <div ref={observerRef}>
+                        </div>
+                    )}
+                </S.SettingContainer>
+            </S.BannerContainer>
         </S.Panel>
     );
 };

--- a/src/pages/CrewSetting/components/CrewActivity.jsx
+++ b/src/pages/CrewSetting/components/CrewActivity.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const CrewActivity = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>멤버 활동 관리</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default CrewActivity;

--- a/src/pages/CrewSetting/components/CrewIntro.jsx
+++ b/src/pages/CrewSetting/components/CrewIntro.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const CrewIntro = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>크루 소개 설정</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default CrewIntro;

--- a/src/pages/CrewSetting/components/CrewMember.jsx
+++ b/src/pages/CrewSetting/components/CrewMember.jsx
@@ -1,7 +1,6 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
-
 const CrewMember = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
@@ -11,14 +10,49 @@ const CrewMember = ({ onClose }) => {
 
     return (
         <S.Panel onClick={handlePanelClick}>
-            <S.MyPage onClick={(e) => e.stopPropagation()}>
-                <S.BannerContainer>
+            <S.BannerContainer onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: '560px',
+                    height: '350px',
+                    right: '35%',
+                }}
+            >
+                <S.DeleteContainer>
+                    <S.SettingTitle>
+                        크루 멤버수
+                    </S.SettingTitle>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 멤버수</h2>
-                </S.BannerContainer>
-            </S.MyPage>
+                </S.DeleteContainer>
+                <S.SettingContainer>
+                    <S.SettingTitle>
+                        크루 멤버
+                    </S.SettingTitle>
+                    <S.NumberSetting>
+                        <S.NumberContainer>
+                            {/*멤버수 값 받아야 합니다. */}
+                            <S.TextItem>최소</S.TextItem>
+                            <S.SetNumber type="number"/>
+                            <S.TextItem>명</S.TextItem>
+                        </S.NumberContainer>
+                        <S.TextItem>~</S.TextItem>
+                        <S.NumberContainer>
+                            <S.TextItem>최대</S.TextItem>
+                            <S.SetNumber type="number"/>
+                            <S.TextItem>명</S.TextItem>
+                        </S.NumberContainer>
+                    </S.NumberSetting>
+                </S.SettingContainer>
+                <S.ButtonContainer style={{ marginTop: '40px' }}>
+                        <S.CompletionButton>
+                            수정완료
+                        </S.CompletionButton>
+                        <S.CancelButton onClick={onClose}>
+                            취소
+                        </S.CancelButton>
+                    </S.ButtonContainer>
+            </S.BannerContainer>
         </S.Panel>
     );
 };

--- a/src/pages/CrewSetting/components/CrewMember.jsx
+++ b/src/pages/CrewSetting/components/CrewMember.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const CrewMember = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>크루 멤버수</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default CrewMember;

--- a/src/pages/CrewSetting/components/CrewRule.jsx
+++ b/src/pages/CrewSetting/components/CrewRule.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const CrewRule = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>가입 조건</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default CrewRule;

--- a/src/pages/CrewSetting/components/CrewSchedule.jsx
+++ b/src/pages/CrewSetting/components/CrewSchedule.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const CrewSchedule = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>크루 일정 관리</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default CrewSchedule;

--- a/src/pages/CrewSetting/components/Delete.jsx
+++ b/src/pages/CrewSetting/components/Delete.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const Delete = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>크루 삭제</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default Delete;

--- a/src/pages/CrewSetting/components/LeaderTransfer.jsx
+++ b/src/pages/CrewSetting/components/LeaderTransfer.jsx
@@ -2,7 +2,7 @@ import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const SettingBanner = ({ onClose }) => {
+const LeaderTransfer = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -16,11 +16,11 @@ const SettingBanner = ({ onClose }) => {
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
+                    <h2>리더 위임</h2>
                 </S.BannerContainer>
             </S.MyPage>
         </S.Panel>
     );
 };
 
-export default SettingBanner;
+export default LeaderTransfer;

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -1,7 +1,6 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
-
 const SettingBanner = ({ onClose }) => {
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
@@ -11,14 +10,63 @@ const SettingBanner = ({ onClose }) => {
 
     return (
         <S.Panel onClick={handlePanelClick}>
-            <S.MyPage onClick={(e) => e.stopPropagation()}>
-                <S.BannerContainer>
+            <S.BannerContainer onClick={(e) => e.stopPropagation()}>
+                <S.DeleteContainer>
+                    <S.SettingTitle>
+                        크루 이름 및 배너사진 설정
+                    </S.SettingTitle>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
-                    <h2>크루 이름 및 배너사진 설정</h2>
-                </S.BannerContainer>
-            </S.MyPage>
+                </S.DeleteContainer>
+                <S.SettingContainer>
+                    <S.SettingTitle>크루명</S.SettingTitle>
+                    {/* 크루명 변경 기능 */}
+                    <S.CrewNameInput
+                        type="text"
+                        placeholder="크루명을 입력해주세요"
+                    />
+                    <S.BannerImageContainer>
+                        {/* 배너 이미지 변경 기능 */}
+                        <S.BannerImage>
+                            <input
+                                type="file"
+                                accept="image/*"
+                                onChange={(e) => {
+                                    const file = e.target.files[0];
+                                    if(file) {
+                                        const reader = new FileReader();
+                                        reader.onloadend = () => {
+                                            console.log("이미지가 선택되었습니다:", reader.result);
+                                        };
+                                        reader.readAsDataURL(file);
+                                    }
+                                }}
+                                style={{display: 'none'}}
+                                id="bannerImageInput"
+                            />
+                            <label
+                                htmlFor="bannerImageInput"
+                                style={{
+                                    width: "100%",
+                                    height: "100%",
+                                    cursor: "pointer",
+                                    display: "block"
+                                }}
+                            >
+                            </label>
+                        </S.BannerImage>
+                    </S.BannerImageContainer>
+                </S.SettingContainer>
+                <S.ButtonContainer>
+                    <S.CompletionButton>
+                        수정완료
+                    </S.CompletionButton>
+                    <S.CancelButton onClick={onClose}>
+                        취소
+                    </S.CancelButton>
+                </S.ButtonContainer>
+            </S.BannerContainer>
         </S.Panel>
     );
 };

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -1,0 +1,13 @@
+import * as S from "../Styles/CrewSetting.styles";
+
+const SettingBanner = ({ onClose }) => {
+    return (
+        <S.Panel>
+            <h2>배너 설정</h2>
+            <button onClick={onClose}>닫기</button>
+            {/* 배너 설정 관련 내용 추가 */}
+        </S.Panel>
+    );
+};
+
+export default SettingBanner;

--- a/src/pages/activities/Styles/Activities.styles.js
+++ b/src/pages/activities/Styles/Activities.styles.js
@@ -105,7 +105,7 @@ export const CrewMember = styled.div`
 `;
 
 export const Setting = styled.div`
-    width:100%;
+    width: 100%;
     height:50px;
 
     & > * {
@@ -115,3 +115,7 @@ export const Setting = styled.div`
         cursor: pointer;
     }
 `
+
+export const Link = styled(RouterNavLink)`
+    border:1px solid red;
+`;

--- a/src/pages/activities/components/Banner.jsx
+++ b/src/pages/activities/components/Banner.jsx
@@ -40,8 +40,10 @@ const Banner = () => {
             {/* Banner Image */}
             <S.BannerImage/>
             <S.Setting>
+                <S.Link to="crewSetting">
                 {/* 관리자만 볼 수 있도록 */}
-                <FaCog size={20}/>
+                    <FaCog size={20}/>
+                </S.Link>
             </S.Setting>
         </S.Banner>
     );

--- a/src/pages/activities/components/Banner.jsx
+++ b/src/pages/activities/components/Banner.jsx
@@ -40,7 +40,7 @@ const Banner = () => {
             {/* Banner Image */}
             <S.BannerImage/>
             <S.Setting>
-                <S.Link to="crewSetting">
+                <S.Link to="/crew/crewSetting">
                 {/* 관리자만 볼 수 있도록 */}
                     <FaCog size={20}/>
                 </S.Link>

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -1,14 +1,15 @@
 import { Route, Routes } from "react-router-dom";
 import Layout from "../components/layout/Layout";
-import CrewCreate from "../pages/CrewCreate/CrewCreate";
-import CrewHome from "../pages/CrewHome/CrewHome";
-import CrewMain from "../pages/CrewMain/CrewMain";
-import AddInfo from "../pages/Login/AddInfo";
-import Login from "../pages/Login/Login";
 import Activities from "../pages/activities/Activities";
 import Details from "../pages/activities/components/Details";
 import Community from "../pages/community/Community";
+import CrewCreate from "../pages/CrewCreate/CrewCreate";
+import CrewHome from "../pages/CrewHome/CrewHome";
+import CrewMain from "../pages/CrewMain/CrewMain";
+import Setting from "../pages/CrewSetting/CrewSetting";
 import Home from "../pages/home/Home";
+import AddInfo from "../pages/Login/AddInfo";
+import Login from "../pages/Login/Login";
 
 
 const Router = () => {
@@ -24,6 +25,7 @@ const Router = () => {
                     <Route path="crewActivity" element={<Activities />} />
                     <Route path="crewActivity/:index" element={<Details />} />
                     <Route path="crewCommunity" element={<Community />} />
+                    <Route path="crewSetting" element={<Setting />} />
                 </Route>
             </Route>
         </Routes>


### PR DESCRIPTION
## 변경사항
1. 크루 이름 및 배너사진 설정 팝업창 구현
<br>

![image](https://github.com/user-attachments/assets/7ea1da87-3ed7-4375-9af7-cf6893cd3485)
<br><br>

2. 이미지클릭 시 파일 선택 기능
<br>

![image](https://github.com/user-attachments/assets/742d6326-d1db-449e-ad7d-afad2d8130b4)
<br><br>

## 참고사항
1. api에서 크루명과 배너사진을 불러와야합니다.