### PR TITLE
feat: 회원가입시 카테고리 저장 기능 추가

### DIFF
--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -1,17 +1,22 @@
 import { createContext, useContext, useState } from 'react';
 import { authAPI } from './api';
 
+// 인증 관련 전역 상태를 관리할 Context 생성
 export const AuthContext = createContext();
 
+// 인증 관련 상태와 기능을 제공하는 Provider 컴포넌트
 export const AuthProvider = ({ children }) => {
+    // 로그인 상태 관리
     const [isLoggedIn, setIsLoggedIn] = useState(() =>
         localStorage.getItem('isLoggedIn') === 'true'
     );
     
+    // 인증 토큰 상태 관리
     const [token, setToken] = useState(() =>
         localStorage.getItem('token')
     );
 
+    // 사용자 정보 상태 관리
     const [userInfo, setUserInfo] = useState(() => {
         const savedUserInfo = localStorage.getItem('userInfo');
         if(savedUserInfo){
@@ -24,6 +29,7 @@ export const AuthProvider = ({ children }) => {
         return null;
     });
 
+    // 로그인 처리 함수
     const login = (tokenValue, user) => {
         localStorage.setItem('token', tokenValue);
         localStorage.setItem('isLoggedIn', 'true');
@@ -35,6 +41,7 @@ export const AuthProvider = ({ children }) => {
         setUserInfo(user);
     };
 
+    // 로그아웃 처리 함수
     const logout = async () => {
         try {
             await authAPI.signOut();
@@ -48,6 +55,8 @@ export const AuthProvider = ({ children }) => {
             window.location.href = '/';
         }
     };
+    
+    // Context에 제공할 값들을 객체로 구성
     const value = {
         isLoggedIn,
         token,
@@ -56,6 +65,7 @@ export const AuthProvider = ({ children }) => {
         logout
     };
 
+    // Provider를 통해 자식 컴포넌트들에게 인증 관련 상태와 함수들을 제공
     return (
         <AuthContext.Provider value={value}>
         {children}
@@ -63,7 +73,7 @@ export const AuthProvider = ({ children }) => {
     );
 };
 
-// 커스텀 훅
+// Context를 쉽게 사용하기 위한 커스텀 훅
 export const useAuth = () => {
     const context = useContext(AuthContext);
     if (!context) {

--- a/src/api.js
+++ b/src/api.js
@@ -23,6 +23,7 @@ api.interceptors.request.use(
     }
 );
 
+// 응답 인터셉터
 api.interceptors.response.use(
     (response) => {
         return response;
@@ -45,6 +46,7 @@ api.interceptors.response.use(
 // API
 export const authAPI = {
     signUp: (data) => api.post('/auth/sign-up', data),
+    signUpCategory: (data) => api.post('/users/interests', data),
     signIn: (data) => api.post('/auth/sign-in', data),
     getUserInfo: () => api.get('/users/me'),
     signOut: () => api.post('/auth/sign-out'),

--- a/src/api.js
+++ b/src/api.js
@@ -45,11 +45,17 @@ api.interceptors.response.use(
 );
 // API
 export const authAPI = {
+    // 회원가입
     signUp: (data) => api.post('/auth/sign-up', data),
+    // 카테고리 저장
     signUpCategory: (data) => api.post('/users/interests', data),
+    // 로그인
     signIn: (data) => api.post('/auth/sign-in', data),
+    // 사용자 정보 조회
     getUserInfo: () => api.get('/users/me'),
+    // 로그아웃
     signOut: () => api.post('/auth/sign-out'),
+    // 토큰 재발급
     reissue: () => api.post('/auth/reissue'),
     sendSms: (phoneNumber) => api.post('/auth/send-sms', { toPhoneNumber: phoneNumber }),
     verifySms: (code) => api.post('/auth/verify-sms', { verificationCode: code }),

--- a/src/pages/Login/AddInfo.jsx
+++ b/src/pages/Login/AddInfo.jsx
@@ -1,5 +1,7 @@
 // src/pages/Login/AddInfo.jsx
 import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { authAPI } from "../../api";
 import Category from "./components/Category";
 import UserInfo from "./components/UserInfo";
 import * as S from "./Styles/Login.styles";
@@ -7,17 +9,65 @@ import * as S from "./Styles/Login.styles";
 
 
 const AddInfo = () => {
+    const navigate = useNavigate();
     const [showCategory, setShowCategory] = useState(false);
-    const [formData, setFormData] = useState({});
+    const [formData, setFormData] = useState({
+        email: "",
+        password: "",
+        nickname: "",
+        cp: "",
+        categories: []
+    });
 
-    const handleConfirmCode = (data) => {
-        setFormData(data);
+    const handleConfirmCode = (userData) => {
+        setFormData(prevData => ({
+            ...prevData,
+            ...userData
+        }));
         setShowCategory(true);
     };
 
-    const handleComplete = (selectedCategories) => {
-        console.log(selectedCategories);
-    }
+    const handleCategorySelect = async (selectedCategories) => {
+        try{
+
+            // 회원가입
+            await authAPI.signUp({
+                email: formData.email,
+                password: formData.password,
+                nickname: formData.nickname,
+                cp: formData.cp
+            });
+
+            // 로그인
+            const loginResponse = await authAPI.signIn({
+                email: formData.email,
+                password: formData.password
+            });
+
+            // 토큰 저장
+            const token = loginResponse.headers?.authorization || loginResponse.data?.token;
+
+            if(!token) {
+                throw new Error("토큰이 없습니다.");
+            }
+            
+            localStorage.setItem("token", token);
+
+            // 토큰을 이용하여 카테고리 저장
+            await authAPI.signUpCategory(selectedCategories);
+
+            alert("회원가입이 완료되었습니다!");
+            navigate('/login');
+        } catch (error) {
+            console.error("회원가입 실패:", error);
+            if(error.response?.status === 409) {
+                alert("이미 가입된 이메일입니다.");
+            } else {
+                alert("회원가입에 실패했습니다. 다시 시도해주세요.");
+            }
+            localStorage.removeItem("token");
+        }
+    };
 
     return (
         <S.Container>
@@ -27,7 +77,7 @@ const AddInfo = () => {
                         <UserInfo onConfirm={handleConfirmCode} />
                     </S.Section>
                     <S.Section>
-                        <Category onComplete={handleComplete} formData={formData}/>
+                        <Category onComplete={handleCategorySelect} />
                     </S.Section>
                 </S.SlideContainer>
             </S.AnimationWrapper>

--- a/src/pages/Login/components/Category.jsx
+++ b/src/pages/Login/components/Category.jsx
@@ -1,6 +1,5 @@
+// Category.js
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { authAPI } from '../../../api';
 import Camper from "../../../assets/category/Camper.png";
 import Coin from "../../../assets/category/Coin.png";
 import Easel from "../../../assets/category/Easel.png";
@@ -11,21 +10,21 @@ import SelfDev from "../../../assets/category/SelfDev.png";
 import Star from "../../../assets/category/Star.png";
 import * as S from '../Styles/Login.styles';
 
-const Category = ({ onComplete, formData }) => {
-    const navigate = useNavigate();
+const Category = ({ onComplete }) => {
     const [selectedCategories, setSelectedCategories] = useState([]);
 
     const categories = [
-        { image: Activity, alt: "액티비티", title: "액티비티", subtitle: "다양한 활동을 즐겨보세요" },
-        { image: Easel, alt: "문화·예술", title: "문화·예술", subtitle: "다양한 문화를 즐겨보세요" },
-        { image: SausageBarbeque, alt: "푸드·드링크", title: "푸드·드링크", subtitle: "맛있는 음식을 즐겨보세요" },
-        { image: Star, alt: "취미", title: "취미", subtitle: "다양한 취미를 즐겨보세요" },
-        { image: Camper, alt: "여행", title: "여행", subtitle: "다양한 여행을 즐겨보세요" },
-        { image: SelfDev, alt: "자기계발", title: "자기계발", subtitle: "자기계발을 즐겨보세요" },
-        { image: Coin, alt: "재테크", title: "재테크", subtitle: "재테크를 즐겨보세요" },
-        { image: GameController, alt: "게임", title: "게임", subtitle: "게임을 즐겨보세요" },
+        { image: Activity, alt: "액티비티", title: "ACTIVITY", subtitle: "다양한 활동을 즐겨보세요" },
+        { image: Easel, alt: "문화·예술", title: "CULTURE_ART", subtitle: "다양한 문화를 즐겨보세요" },
+        { image: SausageBarbeque, alt: "푸드·드링크", title: "FOOD", subtitle: "맛있는 음식을 즐겨보세요" },
+        { image: Star, alt: "취미", title: "HOBBY", subtitle: "다양한 취미를 즐겨보세요" },
+        { image: Camper, alt: "여행", title: "TRAVEL", subtitle: "다양한 여행을 즐겨보세요" },
+        { image: SelfDev, alt: "자기계발", title: "SELF_IMPROVEMENT", subtitle: "자기계발을 즐겨보세요" },
+        { image: Coin, alt: "재테크", title: "FINANCE", subtitle: "재테크를 즐겨보세요" },
+        { image: GameController, alt: "게임", title: "GAMING", subtitle: "게임을 즐겨보세요" }
     ];
 
+    // 카테고리 선택
     const handleCategoryClick = (index) => {
         const isSelected = selectedCategories.includes(index);
 
@@ -42,31 +41,19 @@ const Category = ({ onComplete, formData }) => {
         setSelectedCategories([...selectedCategories, index]);
     };
 
-    const handleComplete = async () => {
+    // 카테고리 선택 완료
+    const handleComplete = () => {
         if (selectedCategories.length === 0) {
             alert("최소 1개의 카테고리를 선택해주세요.");
             return;
         }
 
-        const selectedCategoryData = selectedCategories.map(index => ({
-            title: categories[index].title,
-            alt: categories[index].alt,
-        }));
-
-        try {
-            const signUpData = {
-                ...formData,
-                categories: selectedCategoryData
-            };
-            
-            await authAPI.signUp(signUpData);
-            alert("회원가입이 완료되었습니다!");
-            navigate('/login');
-        } catch (error) {
-            console.error("회원가입 실패:", error);
-            alert("회원가입에 실패했습니다. 다시 시도해주세요.");
-        }
-    }
+        const categoryData = {
+            categories: selectedCategories.map(index => categories[index].title)
+        };
+        
+        onComplete(categoryData);
+    };
 
     return (
         <S.CategoryContainer>
@@ -81,7 +68,7 @@ const Category = ({ onComplete, formData }) => {
                     >
                         <S.CategoryImage src={category.image} alt={category.alt} />
                         <S.CategoryTextContainer>
-                            <S.CategoryTitle>{category.title}</S.CategoryTitle>
+                            <S.CategoryTitle>{category.alt}</S.CategoryTitle>
                             <S.CategorySubtitle>{category.subtitle}</S.CategorySubtitle>
                         </S.CategoryTextContainer>
                         <S.SelectButton


### PR DESCRIPTION
## 구현내용

### 카테고리 enum 수정
- 카테고리 title 벡앤드 enum값에 맞춰 수정
![image](https://github.com/user-attachments/assets/9f3fb9a6-f86e-4f47-9833-46437c1bc3d8)

### 2. 카테고리 등록 API 연동 수정 (b2fa56b)
- `/users/interests` 엔드포인트
![image](https://github.com/user-attachments/assets/6b71ae8f-492c-4636-b7b0-390cd665c2cc)

### 3. 회원가입 프로세스 로직 개선
회원가입부터 카테고리 저장까지의 전체 플로우를 순차적으로 처리:
1. 회원가입
 - 이메일, 패스워드, 닉네임, 전화번호 정보로 회원가입
 - 중복 이메일 체크 및 에러 처리
2. 자동 로그인
 - 회원가입 성공 시 입력한 정보로 자동 로그인
 - 로그인 응답에서 인증 토큰 발급
3. 토큰 저장
 - 발급받은 토큰을 localStorage에 저장
 - 이후 API 요청에 사용할 인증 정보로 활용
4. 카테고리 저장
 - 저장된 토큰을 사용하여 선택한 카테고리 정보 저장
![image](https://github.com/user-attachments/assets/7a29065c-0915-425f-a920-454d6210e01e)
<br>

## 테스트 항목
 - [x] 회원가입 후 카테고리 저장 확인