### PR TITLE
feat: 마이페이지 프로필이미지 구현 및 상세 정보 출력

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,6 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -18,7 +18,17 @@ export const AuthProvider = ({ children }) => {
     );
 
     // 사용자 정보 상태 관리
-    const [userInfo, setUserInfo] = useState(null);
+    const [userInfo, setUserInfo] = useState(() => {
+        const savedUserInfo = localStorage.getItem('userInfo');
+        if(savedUserInfo) {
+            try {
+                return JSON.parse(savedUserInfo);
+            } catch {
+                return null;
+            }
+        }
+        return null;
+    });
 
     // 로그인 처리 함수
     const login = async (tokenValue) => {
@@ -30,7 +40,11 @@ export const AuthProvider = ({ children }) => {
 
             // 로그인 후 사용자 정보 가져오기
             const response = await authAPI.getUserInfo();
-            setUserInfo(response.data.data);
+            const userData = response.data.data;
+            
+            // 사용자 정보를 state와 localStorage 모두에 저장
+            localStorage.setItem('userInfo', JSON.stringify(userData));
+            setUserInfo(userData);
         } catch (error) {
             console.error('사용자 정보 요청 실패:', error);
             logout();
@@ -41,6 +55,7 @@ export const AuthProvider = ({ children }) => {
     const logout = () => {
         localStorage.removeItem('token');
         localStorage.removeItem('isLoggedIn');
+        localStorage.removeItem('userInfo');
         setIsLoggedIn(false);
         setToken(null);
         setUserInfo(null);

--- a/src/AuthProvider.jsx
+++ b/src/AuthProvider.jsx
@@ -1,79 +1,68 @@
+// AuthProvider.jsx
 import { createContext, useContext, useState } from 'react';
 import { authAPI } from './api';
 
 // 인증 관련 전역 상태를 관리할 Context 생성
 export const AuthContext = createContext();
 
-// 인증 관련 상태와 기능을 제공하는 Provider 컴포넌트
+// 인증 관련 전역 상태와 기능을 제공하는 Provider 컴포넌트
 export const AuthProvider = ({ children }) => {
-    // 로그인 상태 관리
+    // 로그인 상태를 localStorage에서 가져와 초기화
     const [isLoggedIn, setIsLoggedIn] = useState(() =>
         localStorage.getItem('isLoggedIn') === 'true'
     );
     
-    // 인증 토큰 상태 관리
+    // 토큰을 localStorage에서 가져와 초기화
     const [token, setToken] = useState(() =>
         localStorage.getItem('token')
     );
 
     // 사용자 정보 상태 관리
-    const [userInfo, setUserInfo] = useState(() => {
-        const savedUserInfo = localStorage.getItem('userInfo');
-        if(savedUserInfo){
-            try{
-                return JSON.parse(savedUserInfo);
-            } catch (e){
-                return null;
-            }
-        }
-        return null;
-    });
+    const [userInfo, setUserInfo] = useState(null);
 
     // 로그인 처리 함수
-    const login = (tokenValue, user) => {
-        localStorage.setItem('token', tokenValue);
-        localStorage.setItem('isLoggedIn', 'true');
-        localStorage.setItem('email', user.email);
-        localStorage.setItem('nickname', user.nickname);
+    const login = async (tokenValue) => {
+        try {
+            localStorage.setItem('token', tokenValue);
+            localStorage.setItem('isLoggedIn', 'true');
+            setIsLoggedIn(true);
+            setToken(tokenValue);
 
-        setIsLoggedIn(true);
-        setToken(tokenValue);
-        setUserInfo(user);
+            // 로그인 후 사용자 정보 가져오기
+            const response = await authAPI.getUserInfo();
+            setUserInfo(response.data.data);
+        } catch (error) {
+            console.error('사용자 정보 요청 실패:', error);
+            logout();
+        }
     };
 
     // 로그아웃 처리 함수
-    const logout = async () => {
-        try {
-            await authAPI.signOut();
-        } catch (error) {
-            console.error('로그아웃 API 호출 실패:', error);
-        } finally {
-            localStorage.clear();
-            setIsLoggedIn(false);
-            setToken(null);
-            setUserInfo(null);
-            window.location.href = '/';
-        }
+    const logout = () => {
+        localStorage.removeItem('token');
+        localStorage.removeItem('isLoggedIn');
+        setIsLoggedIn(false);
+        setToken(null);
+        setUserInfo(null);
+        window.location.href = '/';
     };
     
-    // Context에 제공할 값들을 객체로 구성
-    const value = {
-        isLoggedIn,
-        token,
-        userInfo,
-        login,
-        logout
-    };
-
-    // Provider를 통해 자식 컴포넌트들에게 인증 관련 상태와 함수들을 제공
+    // Context Provider 반환
     return (
-        <AuthContext.Provider value={value}>
-        {children}
+        <AuthContext.Provider value={{
+            isLoggedIn,
+            token,
+            userInfo,
+            setUserInfo,
+            login,
+            logout
+        }}>
+            {children}
         </AuthContext.Provider>
     );
 };
 
-// Context를 쉽게 사용하기 위한 커스텀 훅
+// 커스텀 훅: AuthContext 사용을 위한 헬퍼 함수
 export const useAuth = () => {
     const context = useContext(AuthContext);
     if (!context) {

--- a/src/api.js
+++ b/src/api.js
@@ -32,11 +32,7 @@ export const authAPI = {
     getUserInfo: () => api.get('/users/me'),
     sendSms: phoneNumber => api.post('/auth/send-sms', { toPhoneNumber: phoneNumber }),
     verifySms: code => api.post('/auth/verify-sms', { verificationCode: code }),
-    uploadProfileImage: (formData) => api.post('/users/upload-profile', formData, {
-        headers: {
-            'Content-Type': 'multipart/form-data',
-        },
-    }),
+    uploadProfileImage: (formData) => api.post('/users/upload-profile', formData),
     updateUserInfo: (data) => api.put('/users', data),
 };
 

--- a/src/api.js
+++ b/src/api.js
@@ -1,65 +1,43 @@
 import axios from 'axios';
 
+const BASE_URL = 'http://localhost:8080';
+
 const api = axios.create({
-    baseURL: 'http://localhost:8080',
-    headers: {
-        'Content-Type': 'application/json',
-    },
+    baseURL: BASE_URL,
+    headers: { 'Content-Type': 'application/json' },
     withCredentials: true,
 });
 
 // 요청 인터셉터
 api.interceptors.request.use(
-    (config) => {
+    config => {
         const token = localStorage.getItem('token');
         if (token) {
-            config.headers.Authorization = token;
+            config.headers['Authorization'] = token;
+        }
+        // 파일 업로드 요청인 경우 Content-Type 헤더 제거
+        if (config.url === '/users/upload-profile') {
+            delete config.headers['Content-Type'];
         }
         return config;
     },
-    (error) => {
-        console.error('인터셉터 에러:', error);
-        return Promise.reject(error);
-    }
+    error => Promise.reject(error)
 );
 
-// 응답 인터셉터
-api.interceptors.response.use(
-    (response) => {
-        return response;
-    },
-    (error) => {
-        console.error('응답 에러:', {
-            message: error.message,
-            response: error.response?.data,
-            status: error.response?.status
-        });
-        
-        if(error.response?.status === 401){
-            localStorage.clear();
-            window.location.href = '/';
-        }
-
-        return Promise.reject(error);
-    }
-);
-// API
 export const authAPI = {
-    // 회원가입
-    signUp: (data) => api.post('/auth/sign-up', data),
-    // 카테고리 저장
-    signUpCategory: (data) => api.post('/users/interests', data),
-    // 로그인
-    signIn: (data) => api.post('/auth/sign-in', data),
-    // 사용자 정보 조회
-    getUserInfo: () => api.get('/users/me'),
-    // 로그아웃
+    signUp: data => api.post('/auth/sign-up', data),
+    signUpCategory: data => api.post('/users/interests', data),
+    signIn: data => api.post('/auth/sign-in', data),
     signOut: () => api.post('/auth/sign-out'),
-    // 토큰 재발급
-    reissue: () => api.post('/auth/reissue'),
-    sendSms: (phoneNumber) => api.post('/auth/send-sms', { toPhoneNumber: phoneNumber }),
-    verifySms: (code) => api.post('/auth/verify-sms', { verificationCode: code }),
-    
+    getUserInfo: () => api.get('/users/me'),
+    sendSms: phoneNumber => api.post('/auth/send-sms', { toPhoneNumber: phoneNumber }),
+    verifySms: code => api.post('/auth/verify-sms', { verificationCode: code }),
+    uploadProfileImage: (formData) => api.post('/users/upload-profile', formData, {
+        headers: {
+            'Content-Type': 'multipart/form-data',
+        },
+    }),
+    updateUserInfo: (data) => api.put('/users', data),
 };
 
 export default api;

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -30,7 +30,7 @@ const Header = () => {
             <S.Logo to="/">Logo</S.Logo>
             <S.Container>
                 <S.Nav>
-                    <S.StyledNavLink to="/crew">크루</S.StyledNavLink>
+                    <S.StyledNavLink to="/crew/crewHome">크루</S.StyledNavLink>
                     <S.StyledNavLink to="">피드</S.StyledNavLink>
                     <S.StyledNavLink>핫 플레이스</S.StyledNavLink>
                 </S.Nav>

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -16,6 +16,7 @@ const MyPage = ({ closeModal }) => {
     const [showAgeSelect, setShowAgeSelect] = useState(false); // 나이 선택
     const [age, setAge] = useState(''); // 나이 입력값
     const [showAgeInput, setShowAgeInput] = useState(false); // 나이 입력
+    const [updatedUserInfo, setUpdatedUserInfo] = useState(null); // 업데이트된 사용자 정보
 
     // 사용자 정보가 변경될 때마다 닉네임과 프로필 이미지 업데이트
     useEffect(() => {
@@ -50,6 +51,9 @@ const MyPage = ({ closeModal }) => {
                     ...userInfo,
                     profileImage: imageUrl
                 });
+                setUserInfo(updatedUserInfo);
+
+                localStorage.setItem('userInfo', JSON.stringify(updatedUserInfo));
             }
 
             alert('프로필 이미지가 업데이트되었습니다.');
@@ -81,7 +85,10 @@ const MyPage = ({ closeModal }) => {
             });
     
             if (response.data.data) {
-                setUserInfo(prev => ({...prev, ...response.data.data}));
+                const updatedUserInfo = {...userInfo, ...response.data.data};
+                setUserInfo(updatedUserInfo);
+                // localStorage도 함께 업데이트
+                localStorage.setItem('userInfo', JSON.stringify(updatedUserInfo));
                 setShowGenderSelect(false);  // 성공 시에만 UI 닫기
             }
         } catch (error) {
@@ -89,6 +96,7 @@ const MyPage = ({ closeModal }) => {
             alert('성별 업데이트에 실패했습니다.');
         }
     };
+    
 
     // 성별 표시 텍스트 변환
     const displayGender = (gender) => {
@@ -110,9 +118,12 @@ const MyPage = ({ closeModal }) => {
                 cp: userInfo.cp,
                 gender: userInfo.gender
             });
-
+    
             if (response.data.data) {
-                setUserInfo(prev => ({...prev, ...response.data.data}));
+                const updatedUserInfo = {...userInfo, ...response.data.data};
+                setUserInfo(updatedUserInfo);
+                // localStorage도 함께 업데이트
+                localStorage.setItem('userInfo', JSON.stringify(updatedUserInfo));
                 setShowAgeInput(false);
                 setAge('');
             }

--- a/src/components/layout/MyPage.jsx
+++ b/src/components/layout/MyPage.jsx
@@ -1,29 +1,135 @@
-import { useEffect, useState } from "react";
+// 필요한 라이브러리와 컴포넌트 import
+import { useEffect, useRef, useState } from "react";
 import { AiOutlineClose } from "react-icons/ai";
+import { authAPI } from "../../api";
 import { useAuth } from "../../AuthProvider";
 import * as S from "./Styles/Header.styles";
 
-
 const MyPage = ({ closeModal }) => {
-    const [selectedMenu, setSelectedMenu] = useState('crew');
-    const { userInfo } = useAuth();
-    const [nickname, setNickname] = useState('');
+    // 상태 관리
+    const [selectedMenu, setSelectedMenu] = useState('crew'); // 선택된 메뉴 (마이페이지/내크루)
+    const { userInfo, setUserInfo } = useAuth(); // 전역 사용자 정보
+    const [nickname, setNickname] = useState(''); // 사용자 닉네임
+    const [profileImage, setProfileImage] = useState(''); // 프로필 이미지 URL
+    const fileInputRef = useRef(null); // 파일 입력 참조
+    const [showGenderSelect, setShowGenderSelect] = useState(false); // 성별 선택
+    const [showAgeSelect, setShowAgeSelect] = useState(false); // 나이 선택
+    const [age, setAge] = useState(''); // 나이 입력값
+    const [showAgeInput, setShowAgeInput] = useState(false); // 나이 입력
 
+    // 사용자 정보가 변경될 때마다 닉네임과 프로필 이미지 업데이트
     useEffect(() => {
-        if (userInfo && userInfo.data) {
-            setNickname(userInfo.data.nickname || '');
-        } else if (userInfo && userInfo.nickname) {
+        if (userInfo) {
             setNickname(userInfo.nickname || '');
+            setProfileImage(userInfo.profileImage || '');
         }
     }, [userInfo]);
 
+    // 프로필 이미지 업로드 처리
+    const handleProfileImageUpload = async (file) => {
+        if (!file) return;
+    
+        // 이미지 파일 타입 체크
+        if (!file.type.startsWith('image/')) {
+            alert('이미지 파일만 업로드 가능합니다.');
+            return;
+        }
+    
+        const formData = new FormData();
+        formData.append('profileImage', file);
 
+        try {
+            const response = await authAPI.uploadProfileImage(formData);
+            const imageUrl = response.data.data;
+
+            setProfileImage(imageUrl);
+            
+            // 전역 유저 정보 업데이트
+            if (userInfo) {
+                setUserInfo({
+                    ...userInfo,
+                    profileImage: imageUrl
+                });
+            }
+
+            alert('프로필 이미지가 업데이트되었습니다.');
+        } catch (error) {
+            console.error('프로필 이미지 업로드 실패:', error);
+            alert('프로필 이미지 업로드에 실패했습니다.');
+        }
+    };
+
+    // 이미지 클릭 시 파일 선택 다이얼로그 열기
+    const handleImageClick = () => {
+        fileInputRef.current?.click();
+    };
+
+    // 파일 선택 시 이미지 업로드 처리
+    const handleProfileImageChange = (e) => {
+        const file = e.target.files[0];
+        handleProfileImageUpload(file);
+    };
+
+    // 성별 선택 처리
+    const handleGenderSelect = async (gender) => {
+        try {
+            const response = await authAPI.updateUserInfo({
+                gender,
+                nickname: userInfo.nickname,
+                cp: userInfo.cp,
+                age: userInfo.age
+            });
+    
+            if (response.data.data) {
+                setUserInfo(prev => ({...prev, ...response.data.data}));
+                setShowGenderSelect(false);  // 성공 시에만 UI 닫기
+            }
+        } catch (error) {
+            console.error('성별 업데이트 실패:', error);
+            alert('성별 업데이트에 실패했습니다.');
+        }
+    };
+
+    // 성별 표시 텍스트 변환
+    const displayGender = (gender) => {
+        if(!gender) return '성별 선택';
+        return gender === 'M' ? '남성' : '여성';
+    }
+
+    // 나이 제출 처리
+    const handleAgeSubmit = async () => {
+        if (!age || age < 1 || age > 100) {
+            alert('1-100 사이의 나이를 입력해주세요.');
+            return;
+        }
+    
+        try {
+            const response = await authAPI.updateUserInfo({
+                age: parseInt(age),
+                nickname: userInfo.nickname,
+                cp: userInfo.cp,
+                gender: userInfo.gender
+            });
+
+            if (response.data.data) {
+                setUserInfo(prev => ({...prev, ...response.data.data}));
+                setShowAgeInput(false);
+                setAge('');
+            }
+        } catch (error) {
+            console.error('나이 업데이트 실패:', error);
+            alert('나이 업데이트에 실패했습니다.');
+        }
+    };
+
+    // 모달 외부 클릭 시 닫기
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             closeModal();
         }
     }
 
+    // 사용자 패널 클릭 이벤트 전파 방지
     const handleUserPanelClick = (e) => {
         e.stopPropagation();
     }
@@ -35,41 +141,118 @@ const MyPage = ({ closeModal }) => {
                     <S.CloseButton onClick={closeModal}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
+                    {/* 숨겨진 파일 입력 */}
+                    <input
+                        type="file"
+                        ref={fileInputRef}
+                        onChange={handleProfileImageChange}
+                        accept="image/*"
+                        style={{ display: 'none' }}
+                    />
                     {/* 프로필 이미지 */}
-                    <S.ProfileImage/>
-                    {/* 사용자 닉네임 or 이름 */}
+                    <S.ProfileImage
+                        onClick={handleImageClick}
+                        style={{
+                            backgroundImage: profileImage ? `url(${profileImage})` : 'none',
+                            cursor: 'pointer',
+                            width: '90px',
+                            height: '90px',
+                            backgroundSize: 'cover',
+                            backgroundPosition: 'center'
+                        }}
+                    />
+                    {/* 사용자 정보 표시 */}
                     <S.UserInfo>
                         <S.Name>{nickname}</S.Name>
-                        {/* 매너점수를 score에 넣어 출력 */}
-                        <S.Manners score={25.1}/>
+                        <S.Manners $score={25.1}/>
                     </S.UserInfo>
                 </S.UserPanel>
+                {/* 메뉴 선택 버튼 */}
                 <S.SelectButton>
                     <S.Button
                         onClick={() => setSelectedMenu('mypage')}
-                        className={selectedMenu === 'mypage' ? 'active': ''}
+                        style={{ fontWeight: selectedMenu === 'mypage' ? 600 : '' }}
                     >
                         마이페이지
                     </S.Button>
                     <S.Button
                         onClick={() => setSelectedMenu('crew')}
-                        className={selectedMenu === 'crew' ? 'active': ''}
+                        style={{ fontWeight: selectedMenu === 'crew' ? 600 : '' }}
                     >
                         내 크루
                     </S.Button>
                 </S.SelectButton>
+                {/* 컨텐츠 영역 */}
                 <S.ContentContainer>
+                    {/* 마이페이지 컨텐츠 */}
                     {selectedMenu === 'mypage' && (
                         <S.MyPageContent>
-                            <p>마이페이지</p>
+                            <S.UserInfoContainer>
+                                <S.infoTitle>이메일:</S.infoTitle> {userInfo.email}
+                            </S.UserInfoContainer>
+                            <S.UserInfoContainer>
+                                <S.infoTitle>닉네임:</S.infoTitle> {userInfo.nickname}
+                            </S.UserInfoContainer>
+                            <S.UserInfoContainer>
+                                <S.infoTitle>전화번호:</S.infoTitle> {userInfo.cp}
+                            </S.UserInfoContainer>
+                            {/* 성별 정보 */}
+                            <S.UserInfoContainer>
+                                <S.infoTitle>성별:</S.infoTitle>
+                                {showGenderSelect ? (
+                                    <S.GenderSelectContainer>
+                                        <S.GenderButton onClick={() => handleGenderSelect('M')}>남성</S.GenderButton>
+                                        <S.GenderButton onClick={() => handleGenderSelect('F')}>여성</S.GenderButton>
+                                    </S.GenderSelectContainer>
+                                ) : (
+                                    <>
+                                        <S.infoTitle>{displayGender(userInfo?.gender)}</S.infoTitle>
+                                        {!userInfo?.gender && (
+                                            <S.EditButton onClick={() => setShowGenderSelect(true)}>
+                                                수정
+                                            </S.EditButton>
+                                        )}
+                                    </>
+                                )}
+                            </S.UserInfoContainer>
+                            {/* 나이 정보 */}
+                            <S.UserInfoContainer>
+                                <S.infoTitle>나이:</S.infoTitle>
+                                {showAgeInput ? (
+                                    <S.AgeInputContainer>
+                                        <S.AgeInput
+                                            type="number"
+                                            value={age}
+                                            onChange={(e) => setAge(e.target.value)}
+                                            min="1"
+                                            max="100"
+                                        />
+                                        <S.SubmitButton onClick={handleAgeSubmit}>
+                                            확인
+                                        </S.SubmitButton>
+                                        <S.CancelButton onClick={() => setShowAgeInput(false)}>
+                                            취소
+                                        </S.CancelButton>
+                                    </S.AgeInputContainer>
+                                ) : (
+                                    <>
+                                        <span>{userInfo?.age || '미설정'}</span>
+                                        {(!userInfo?.age || userInfo?.age === 0) && (
+                                            <S.EditButton onClick={() => setShowAgeInput(true)}>
+                                                수정
+                                            </S.EditButton>
+                                        )}
+                                    </>
+                                )}
+                            </S.UserInfoContainer>
                         </S.MyPageContent>
                     )}
+                    {/* 크루 컨텐츠 */}
                     {selectedMenu === 'crew' && (
                         <S.CrewContent>
                             <S.CrewList>
-                                {/* 크루는 최대 5개까지만 들어갈 수 있다. */}
+                                {/* 크루 목록 (최대 5개) */}
                                 {[...Array(2)].map((_, index) => (
-                                    // 해당 크루 페이지로 이동할 수 있도록 추후 수정
                                     <S.CrewItem key={index}>
                                         <S.CrewImage/>
                                         <S.CrewName>
@@ -81,6 +264,7 @@ const MyPage = ({ closeModal }) => {
                                     </S.CrewItem>
                                 ))}
                             </S.CrewList>
+                            {/* 크루 생성 버튼 */}
                             <S.CreateCrewButton to="/crewcreate" onClick={closeModal}>
                                 크루 생성
                             </S.CreateCrewButton>

--- a/src/components/layout/Styles/Header.styles.js
+++ b/src/components/layout/Styles/Header.styles.js
@@ -107,13 +107,26 @@ export const CloseButton = styled.div`
     cursor: pointer;
 `;
 
-export const ProfileImage = styled.img`
+export const ProfileImage = styled.div`
     width: 90px;
     height: 90px;
     border-radius: 50%;
-    border: 1px solid #fff;
-    display: flex;
+    background-color: #ddd;
+    position: relative;
     margin-left:30px;
+
+    &:hover::after {
+        content: '이미지 변경';
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background-color: rgba(0, 0, 0, 0.5);
+        color: white;
+        padding: 5px;
+        border-radius: 4px;
+        font-size: 12px;
+    }
 `;
 
 export const UserInfo = styled.div`
@@ -146,11 +159,11 @@ export const Manners = styled.p`
         content: '';
         position: absolute;
         height:100%;
-        width: ${props => props.score || 0}%;
+        width: ${props => props.$score || 0}%;
 
         background: ${props => {
-            if (props.score < 30) return '#FF666F'; //빨간색
-            if (props.score < 60) return '#FF9F3E'; //주황색
+            if (props.$score < 30) return '#FF666F'; //빨간색
+            if (props.$score < 60) return '#FF9F3E'; //주황색
             return '#75C1A7'; //초록색
         }};
         border-radius: 4px;
@@ -158,13 +171,13 @@ export const Manners = styled.p`
     }
 
     &::after {
-        content: '${props => props.score || 0}℃';
+        content: '${props => props.$score || 0}℃';
         position: absolute;
         top:-20px;
         right: 0;
         color:${props => {
-            if (props.score < 30) return '#FF666F';
-            if (props.score < 60) return '#FF9F3E';
+            if (props.$score < 30) return '#FF666F';
+            if (props.$score < 60) return '#FF9F3E';
             return '#75C1A7';
         }};
         font-size:13px;
@@ -189,7 +202,8 @@ export const ContentContainer = styled.div`
 `;
 
 export const MyPageContent = styled.div`
-    height:250px;
+    padding: 20px 0;
+    min-height:250px;
 `;
 
 export const CrewContent = styled.div`
@@ -242,3 +256,91 @@ export const CrewMember = styled.p`
     bottom: 15px;
     right: 30px;
 `
+
+export const UserInfoContainer = styled.div`
+    font-size: 14px;
+    width: 100%;
+    margin: 10px 40px;
+    margin-bottom: 5px;
+    float: left;
+    
+`;
+
+export const infoTitle = styled.p`
+    width: 60px;
+    font-weight: 600;
+    margin-right: 10px;
+    display: inline;
+    float: left;
+`;
+
+export const GenderSelectContainer = styled.div`
+    display: flex;
+    gap: 10px;
+`;
+
+export const GenderButton = styled.button`
+    padding: 8px 16px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: white;
+    cursor: pointer;
+    
+    &:hover {
+        background-color: #f0f0f0;
+    }
+`;
+
+export const EditButton = styled.button`
+    margin-left: 10px;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background-color: white;
+    font-size: 12px;
+    cursor: pointer;
+    
+    &:hover {
+        background-color: #f0f0f0;
+    }
+`;
+
+
+export const AgeInputContainer = styled.div`
+    display: flex;
+    gap: 8px;
+    align-items: center;
+`;
+
+export const AgeInput = styled.input`
+    width: 60px;
+    padding: 4px 8px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+`;
+
+export const SubmitButton = styled.button`
+    padding: 4px 8px;
+    background-color: #4CAF50;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    
+    &:hover {
+        background-color: #45a049;
+    }
+`;
+
+export const CancelButton = styled.button`
+    padding: 4px 8px;
+    background-color: #f44336;
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    
+    &:hover {
+        background-color: #da190b;
+    }
+`;

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -37,44 +37,22 @@ const Login = () => {
         e.preventDefault();
         
         try {
-            // 1. 로그인 요청
             const loginResponse = await authAPI.signIn(formData);
             
             if (loginResponse.headers.authorization) {
-                // 2. 토큰 저장
                 const token = loginResponse.headers.authorization;
-                localStorage.setItem('token', token);
-                localStorage.setItem('isLoggedIn', 'true');
                 
-                try {
-                    // 3. 사용자 정보 조회
-                    const userResponse = await authAPI.getUserInfo();
-                    const userData = userResponse.data.data;
-                
-                    // 4. 사용자 정보 저장
-                    localStorage.setItem('userInfo', JSON.stringify(userData));
-                    
-                    // 5. Context 업데이트
-                    login(token, userData);  // userData 직접 전달
-                    
-                    navigate('/', { replace: true });
-                } catch (userError) {
-                    setError('사용자 정보를 가져오는데 실패했습니다.');
-                }
+                // 토큰만 전달하여 로그인 처리
+                await login(token);
+                navigate('/', { replace: true });
             } else {
                 setError('로그인 응답에 토큰이 없습니다.');
             }
         } catch (error) {
-            if (error.response) {
-                setError(error.response.data.message || '로그인에 실패했습니다.');
-            } else if (error.request) {
-                setError('서버 응답이 없습니다.');
-            } else {
-                setError('요청 중 오류가 발생했습니다.');
-            }
+            setError(error.response?.data?.message || '로그인에 실패했습니다.');
         }
     };
-
+    
     const handleSignUp = () => {
         navigate('/signup');
     };
@@ -87,23 +65,23 @@ const Login = () => {
                 </S.AddInfoTitle>
                 {error && <S.ErrorMessage>{error}</S.ErrorMessage>}
                 <S.InputWrapper>
-                    <S.LoginInput 
-                        type="email" 
+                    <S.LoginInput
+                        type="email"
                         name="email"
                         value={formData.email}
                         onChange={handleChange}
-                        autoComplete="email" 
-                        placeholder="이메일을 입력해주세요." 
+                        autoComplete="email"
+                        placeholder="이메일을 입력해주세요."
                     />
                 </S.InputWrapper>
                 <S.InputWrapper>
-                    <S.LoginInput 
-                        type="password" 
+                    <S.LoginInput
+                        type="password"
                         name="password"
                         value={formData.password}
                         onChange={handleChange}
-                        autoComplete="current-password" 
-                        placeholder="비밀번호를 입력해주세요." 
+                        autoComplete="current-password"
+                        placeholder="비밀번호를 입력해주세요."
                     />
                 </S.InputWrapper>
                 <S.InputWrapper>

--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -10,7 +10,7 @@ import * as S from "./Styles/Login.styles";
 
 const Login = () => {
     const navigate = useNavigate();
-    const { login, setUserInfo } = useAuth();
+    const { login } = useAuth();
 
     const [formData, setFormData] = useState({
         email: "",


### PR DESCRIPTION
# 구현내용

https://github.com/user-attachments/assets/c77e13fa-2c56-4146-bd90-3031fde79c92


## 로그인 및 사용자 정보 관리 기능 개선
#### 1. 로그인 처리 로직을 AuthProvider로 통합하고 사용자 정보 관리 방식을 개선
#### 2. 마이페이지에서 사용자 정보 수정 기능(프로필 이미지, 나이, 성별)을 추가하고 API 연동

## 변경사항

### 인증 관리 개선 (AuthProvider)
 - 페이지 새로고침 시 사용자 정보 유지 기능 구현
 - 페이지 로드 시 자동으로 사용자 정보 갱신
 - 로그인 후 getUserInfo API를 통해 사용자 정보 조회 로직 구현
 - 로그인 실패 시 자동 로그아웃 처리 추가

### 마이페이지 기능 구현 (Mypage)
 - 프로필 이미지 업로드 기능
 - gender 값이 null일 시 선택/수정 기능
 - age 값이 0일 시 입력/수정 기능
 - 사용자 상세 정보 표시 (email, nickname, cp, gender, age)

### UI/UX 개선
 - 프로필 이미지 업로드 UI 구현
 - 성별/나이 수정을 위한 UI 추가
 - 사용자 정보 표시 레이아웃 개선

### 테스트 항목
 - [x] 로그인 후 사용자 정보가 정상적으로 조회되는지 확인
 - [x] 로그아웃 시 모든 상태가 정상적으로 초기화되는지 확인
 - [x] 프로필 이미지 업로드 기능 동작 확인
 - [x] 성별 선택/수정 기능 동작 확인
 - [x] 나이 입력/수정 기능 동작 확인
 - [x] 사용자 정보 업데이트 API 연동 확인
 - [x] 새로고침 시 최신 사용자 정보 유지

## 추가 고려사항
 - 추후 소셜 로그인 기능 추가 시 현재 구조를 활용하여 확장할 수 있습니다.
 - 토큰과 리프레시 토큰이 로컬환경에서 정상적으로 들어가나 갱신이 안되고, 배포서버에서는 리프레시토큰이 들어가지않는 오류