### PR TITLE
feat: 토큰 자동 갱신 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,11 +11,8 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
-<<<<<<< HEAD
         "moment": "^2.30.1",
-=======
         "axios": "^1.7.9",
->>>>>>> 5fa03e4332ee7d2b0ea6b1e2eda79465522268da
         "react": "^18.3.1",
         "react-calendar": "^5.1.0",
         "react-dom": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,8 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
-<<<<<<< HEAD
     "moment": "^2.30.1",
-=======
     "axios": "^1.7.9",
->>>>>>> 5fa03e4332ee7d2b0ea6b1e2eda79465522268da
     "react": "^18.3.1",
     "react-calendar": "^5.1.0",
     "react-dom": "^18.3.1",

--- a/src/api.js
+++ b/src/api.js
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
-// const BASE_URL = 'http://localhost:8080';
-const BASE_URL = 'http://13.124.54.225:8080';
+const BASE_URL = 'https://modumoim.site';
 
 const api = axios.create({
     baseURL: BASE_URL,
@@ -13,7 +12,7 @@ const api = axios.create({
 api.interceptors.request.use(
     config => {
         const token = localStorage.getItem('token');
-        if (token) {
+        if (token && config.url !== '/auth/reissue') {
             config.headers['Authorization'] = token;
         }
         // 파일 업로드 요청인 경우 Content-Type 헤더 제거
@@ -23,6 +22,46 @@ api.interceptors.request.use(
         return config;
     },
     error => Promise.reject(error)
+);
+
+
+// 응답 인터셉터 설정
+api.interceptors.response.use(
+    // 정상 응답인 경우 그대로 반환
+    (response) => response,
+    // 에러 발생 시 처리
+    async (error) => {
+        const originalRequest = error.config;
+        
+        // 401 에러(인증 실패)이고 재시도하지 않은 요청인 경우
+        if (error.response?.status === 401 && !originalRequest._retry) {
+            // 재시도 표시
+            originalRequest._retry = true;
+            
+            try {
+                // 저장된 토큰에서 'Bearer ' 제거
+                const token = localStorage.getItem('token')?.replace('Bearer ', '');
+                
+                // 토큰 재발급 요청
+                const response = await authAPI.reissue(token);
+
+                // 새로운 토큰이 있으면 저장하고 원래 요청 재시도
+                const newToken = response.headers['authorization'];
+                if (newToken) {
+                    localStorage.setItem('token', newToken);
+                    originalRequest.headers['Authorization'] = newToken;
+                    return api(originalRequest);
+                }
+            } catch (error) {
+                // 토큰 재발급 실패 시 로그인 페이지로 이동
+                console.error('토큰 재발급 실패:', error);
+                localStorage.removeItem('token');
+                window.location.href = '/signin';
+            }
+        }
+        // 그 외 에러는 그대로 반환
+        return Promise.reject(error);
+    }
 );
 
 export const authAPI = {
@@ -35,6 +74,19 @@ export const authAPI = {
     verifySms: code => api.post('/auth/verify-sms', { verificationCode: code }),
     uploadProfileImage: (formData) => api.post('/users/upload-profile', formData),
     updateUserInfo: (data) => api.put('/users', data),
+    reissue: (token) => api.post('/auth/reissue',
+        { expiredAccessToken: token },
+        {
+            withCredentials: true,
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        }
+    ),
+};
+
+export const crewAPI = {
+    getCrewList: () => api.get('/crews'),
 };
 
 export default api;

--- a/src/api.js
+++ b/src/api.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
-const BASE_URL = 'http://localhost:8080';
+// const BASE_URL = 'http://localhost:8080';
+const BASE_URL = 'http://13.124.54.225:8080';
 
 const api = axios.create({
     baseURL: BASE_URL,

--- a/src/api.js
+++ b/src/api.js
@@ -56,7 +56,7 @@ api.interceptors.response.use(
                 // 토큰 재발급 실패 시 로그인 페이지로 이동
                 console.error('토큰 재발급 실패:', error);
                 localStorage.removeItem('token');
-                window.location.href = '/signin';
+                window.location.href = '/login';
             }
         }
         // 그 외 에러는 그대로 반환

--- a/src/api.js
+++ b/src/api.js
@@ -12,7 +12,9 @@ const api = axios.create({
 api.interceptors.request.use(
     config => {
         const token = localStorage.getItem('token');
-        if (token && config.url !== '/auth/reissue') {
+
+        // 토큰이 있고 재발급 요청이 아닌 경우 헤더에 토큰 추가
+        if (token && !config.url.includes('reissue')) {
             config.headers['Authorization'] = token;
         }
         // 파일 업로드 요청인 경우 Content-Type 헤더 제거

--- a/src/components/layout/Header.jsx
+++ b/src/components/layout/Header.jsx
@@ -30,7 +30,7 @@ const Header = () => {
             <S.Logo to="/">Logo</S.Logo>
             <S.Container>
                 <S.Nav>
-                    <S.StyledNavLink to="/crew/crewHome">크루</S.StyledNavLink>
+                    <S.StyledNavLink to="/crewList">크루</S.StyledNavLink>
                     <S.StyledNavLink to="">피드</S.StyledNavLink>
                     <S.StyledNavLink>핫 플레이스</S.StyledNavLink>
                 </S.Nav>

--- a/src/pages/CrewList/CrewList.jsx
+++ b/src/pages/CrewList/CrewList.jsx
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+import { crewAPI } from "../../api";
+import * as S from "./Styles/CrewList.styles";
+
+const CrewList = () => {
+    const [crews, setCrews] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchCrews = async () => {
+            try {
+                const response = await crewAPI.getCrewList();
+                // console.log('Response:', response.data.data); // 데이터 확인용
+                setCrews(response.data.data);
+            } catch (error) {
+                console.error('크루 목록 조회 실패:', error);
+            } finally {
+                setLoading(false);
+            }
+        };
+
+        fetchCrews();
+    }, []);
+
+    if (loading) return <S.Container>로딩 중...</S.Container>;
+
+    return (
+        <S.Container>
+            <S.FilterSection>
+                <S.SearchInput
+                    type="text"
+                    placeholder="크루 검색"
+                />
+                {/* 생성일 오름차 내림차 정렬 버튼 */}
+            </S.FilterSection>
+            <S.FilterSection>
+                <S.FilterButton>생성일</S.FilterButton>
+            </S.FilterSection>
+            {crews.map((crew) => (
+                <S.CrewCard key={crew.crewId}>
+                    <S.CrewImage />
+                    <S.CrewInfo>
+                        <S.CrewName>{crew.name}</S.CrewName>
+                        <S.CrewCategory>{crew.category}</S.CrewCategory>
+                        <S.CrewMemberCount>멤버 {crew.memberCount}명</S.CrewMemberCount>
+                    </S.CrewInfo>
+                </S.CrewCard>
+            ))}
+        </S.Container>
+    );
+};
+
+
+export default CrewList;

--- a/src/pages/CrewList/Styles/CrewList.styles.js
+++ b/src/pages/CrewList/Styles/CrewList.styles.js
@@ -1,0 +1,78 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+    width: 1024px;
+    margin: 0 auto;
+    padding: 40px 20px;
+`;
+
+export const FilterSection = styled.div`
+    display: flex;
+    gap: 15px;
+    margin-bottom: 30px;
+`;
+
+export const SearchInput = styled.input`
+    padding: 10px 15px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    width: 100%;
+    font-size: 14px;
+`;
+
+export const FilterButton = styled.button`
+    padding: 8px 20px;
+    border: 1px solid #ddd;
+    border-radius: 5px;
+    background: white;
+    cursor: pointer;
+    font-size: 14px;
+    
+    &:hover {
+        background: #f5f5f5;
+    }
+`;
+
+export const CrewCard = styled.div`
+    width:30%;
+    margin: 15px;
+    padding: 10px;
+    border: 1px solid #ddd;
+    border-radius: 10px;
+    overflow: hidden;
+    transition: transform 0.2s;
+    cursor: pointer;
+    float:left;
+    
+    &:hover {
+        transform: translateY(-5px);
+    }
+`;
+
+export const CrewImage = styled.div`
+    width: 100%;
+    min-height: 200px;
+    border:1px solid red;
+`;
+
+export const CrewInfo = styled.div`
+    padding: 15px 5px;
+`;
+
+export const CrewName = styled.h3`
+    font-size: 18px;
+    font-weight: 600;
+    margin-bottom: 8px;
+`;
+
+export const CrewCategory = styled.p`
+    font-size: 14px;
+    color: #666;
+    margin-bottom: 8px;
+`;
+
+export const CrewMemberCount = styled.p`
+    font-size: 14px;
+    color: #352EAE;
+    font-weight: 500;
+`;

--- a/src/pages/CrewMain/CrewMain.jsx
+++ b/src/pages/CrewMain/CrewMain.jsx
@@ -1,7 +1,7 @@
-import styled from "styled-components";
-import FloatingMenu from "./components/FloatingMenu";
 import { Outlet } from "react-router-dom";
+import styled from "styled-components";
 import Banner from "../activities/components/Banner";
+import FloatingMenu from "./components/FloatingMenu";
 
 export default function CrewMain() {
     return(

--- a/src/pages/community/Community.jsx
+++ b/src/pages/community/Community.jsx
@@ -1,8 +1,9 @@
 import { useEffect, useRef, useState } from 'react';
-import Banner from "../activities/components/Banner";
+import { useNavigate } from 'react-router-dom';
 import * as S from "./Styles/Community.styles";
 
 const Community = () => {
+    const navigate = useNavigate();
     // 초기 게시물 데이터 추후 API로 데이터 받아오기
     const initialPosts = Array.from({ length: 12 }, (_, index) => ({
         id: index,
@@ -42,6 +43,9 @@ const Community = () => {
     return(
         <S.Container>
             <S.List>
+                <S.FloatingButton onClick={() => navigate('/crew/crewCommunity/write')}>
+                    글작성
+                </S.FloatingButton>
                 {posts.slice(0, visiblePosts).map((post, index) => (
                 <S.ActivityCard key={post.id}>
                     <S.UserInfoContainer>

--- a/src/pages/community/Styles/Community.styles.js
+++ b/src/pages/community/Styles/Community.styles.js
@@ -106,3 +106,56 @@ export const Title = styled(RouterNavLink)`
     font-size: 15px;
     font-weight: 600;
 `;
+
+export const FloatingButton = styled.button`
+    position: fixed;
+    bottom: 30px;
+    right: 22%;
+    width: 60px;
+    height: 60px;
+    border-radius: 50%;
+    background-color: #352EAE;  // 메인 컬러
+    color: white;
+    border: none;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.15);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 100;
+    transition: all 0.3s ease;
+
+
+    &:hover {
+        background-color: #2A258A;
+        transform: translateY(-2px);
+        transition: all 0.3s ease;
+    }
+`;
+
+
+// WriteCommunity.jsx
+
+export const QuillContainer = styled.div`
+    margin: 100px 0;
+    background-color: #fff;
+    position: relative;
+
+    .ql-container {
+        min-height: 500px;
+    }
+    
+    .ql-editor {
+        min-height: 500px;
+        padding: 20px;
+        font-size: 16px;
+    }
+
+    .ql-toolbar {
+        position: sticky;
+        top: 0;
+        z-index: 1000;
+        background-color: #fff;
+        border: 1px solid #ccc;
+    }
+`;

--- a/src/pages/community/components/writeCommunity.jsx
+++ b/src/pages/community/components/writeCommunity.jsx
@@ -1,9 +1,49 @@
+import { useRef, useState } from 'react';
+import ReactQuill from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
 import * as S from '../Styles/Community.styles';
 
 const WriteCommunity = () => {
+    const [content, setContent] = useState('');
+    const quillRef = useRef(null);
+
+    const modules = {
+        toolbar: [
+            [{ 'header': [1, 2, 3, false] }],
+            ['bold', 'italic', 'underline', 'strike'],
+            [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+            ['link', 'image'],
+            [{ 'color': [] }, { 'background': [] }],
+            ['clean']
+        ],
+    };
+    
+    const formats = [
+        'header',
+        'bold', 'italic', 'underline', 'strike',
+        'list', 'bullet',
+        'link', 'image',
+        'color', 'background'
+    ];
+
+    const handleSubmit = () => {
+        console.log(content);
+    }
+
     return (
         <S.Container>
-            글작성
+            <S.QuillContainer>
+                <ReactQuill
+                    ref={quillRef}
+                    value={content}
+                    onChange={setContent}
+                    modules={modules}
+                    formats={formats}
+                />
+            </S.QuillContainer>
+            <S.FloatingButton onClick={handleSubmit}>
+                작성완료
+            </S.FloatingButton>
         </S.Container>
     );
 };

--- a/src/pages/community/components/writeCommunity.jsx
+++ b/src/pages/community/components/writeCommunity.jsx
@@ -1,0 +1,11 @@
+import * as S from '../Styles/Community.styles';
+
+const WriteCommunity = () => {
+    return (
+        <S.Container>
+            글작성
+        </S.Container>
+    );
+};
+
+export default WriteCommunity;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -6,6 +6,7 @@ import Community from "../pages/community/Community";
 import WriteCommunity from "../pages/community/components/WriteCommunity";
 import CrewCreate from "../pages/CrewCreate/CrewCreate";
 import CrewHome from "../pages/CrewHome/CrewHome";
+import CrewList from "../pages/CrewList/CrewList";
 import CrewMain from "../pages/CrewMain/CrewMain";
 import AddNotice from "../pages/CrewNotice/Components/AddNotice";
 import UpdateNotice from "../pages/CrewNotice/Components/UpdateNotice";
@@ -36,6 +37,7 @@ const Router = () => {
                 </Route>
                 <Route path="/crew/crewSchedule" element={<CrewSchedule />} />
                 <Route path="/crew/crewCommunity/write" element={<WriteCommunity />} />
+                <Route path="/crewList" element={<CrewList />} />
             </Route>
         </Routes>
     )

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -3,15 +3,16 @@ import Layout from "../components/layout/Layout";
 import Activities from "../pages/activities/Activities";
 import Details from "../pages/activities/components/Details";
 import Community from "../pages/community/Community";
+import WriteCommunity from "../pages/community/components/WriteCommunity";
 import CrewCreate from "../pages/CrewCreate/CrewCreate";
 import CrewHome from "../pages/CrewHome/CrewHome";
 import CrewMain from "../pages/CrewMain/CrewMain";
 import AddNotice from "../pages/CrewNotice/Components/AddNotice";
 import UpdateNotice from "../pages/CrewNotice/Components/UpdateNotice";
 import CrewNotice from "../pages/CrewNotice/CrewNotice";
+import CrewSchedule from "../pages/CrewSchedule/CrewSchedule";
 import Setting from "../pages/CrewSetting/CrewSetting";
 import Home from "../pages/home/Home";
-import CrewSchedule from "../pages/CrewSchedule/CrewSchedule";
 import AddInfo from "../pages/Login/AddInfo";
 import Login from "../pages/Login/Login";
 

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -34,6 +34,7 @@ const Router = () => {
                     <Route path="crewSetting" element={<Setting />} />
                 </Route>
                 <Route path="/crew/crewSchedule" element={<CrewSchedule />} />
+                <Route path="/crew/crewCommunity/write" element={<WriteCommunity />} />
             </Route>
         </Routes>
     )


### PR DESCRIPTION
# 구현내용

## 토큰 자동 갱신 기능 구현

#### 1. 토큰 자동 갱신을 위한 응답 인터셉터 추가
## CrewList 페이지 추가
#### 1. 모든 모임 리스트를 볼 수 있는 CrewList 페이지 추가

<br>

## 변경사항

### API 모듈 개선

 - `api.interceptors.response.use` 를 활용하여 401 인증 실패 발생 시 자동으로 
토큰을 재발급하는 로직 추가
 - 기존 토큰에서 `Bearer`문자열 제거 후 reissue API 호출
 - 새로 발급된 토큰이 존재하면 localStorage에 저장하고 원래 요청 재시도
 - 재발급 실패 시 자동 로그아웃 후 로그인 페이지로 이동

### 크루리스트 페이지 구현 (CrewList)
 - `crewAPI.getCrewList`를 추가하여 전체 모임 목록을 조회하는 API 연동

### 테스트 항목

 - [x] 토큰 만료 시 자동 갱신 동작 확인

 - [x] 토큰 갱신 확인 ( 사용자 정보 )

 - [x] 갱신 실패 시 로그아웃 처리 확인

 - [x] reissue API 정상 동작 확인

 - [x] crewList API 정상 동작 확인


## 추가 고려사항

 - crewList는 로컬환경에서만 동작확인을 해서 배포서버에서도 확인이 필요합니다.