### PR TITLE
feat: 크루설정 - 크루명, 크루멤버수, 크루가입조건 api 구현

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -115,6 +115,7 @@ export const crewAPI = {
     uploadImage: (formData, config) => api.post('/crews/images', formData, config),
     createIntro: (data) => api.post('/crews', data),
     getMyCrewList: () => api.get('/crews/me'),
+    updateCrewData: (crewId, formData) => api.put(`/crews/${crewId}`, formData),
 };
 
 export const scheduleAPI = {

--- a/src/api.js
+++ b/src/api.js
@@ -115,7 +115,11 @@ export const crewAPI = {
     uploadImage: (formData, config) => api.post('/crews/images', formData, config),
     createIntro: (data) => api.post('/crews', data),
     getMyCrewList: () => api.get('/crews/me'),
-    updateCrewData: (crewId, formData) => api.put(`/crews/${crewId}`, formData),
+    updateCrewData: (crewId, formData) => api.put(`/crews/${crewId}`, formData, {
+        headers: {
+            "Content-Type": "multipart/form-data",
+        },
+    }),
 };
 
 export const scheduleAPI = {

--- a/src/pages/CrewMain/components/Banner.jsx
+++ b/src/pages/CrewMain/components/Banner.jsx
@@ -66,7 +66,7 @@ const Banner = () => {
             {/* Banner Image */}
             <S.BannerImage src={crewInfoData?.bannerImage}/>
             <S.Setting>
-                <S.Link to="/crew/crewSetting">
+                <S.Link to={`/crews/${crewId}/crewSetting`}>
                 {/* 관리자만 볼 수 있도록 */}
                     <FaCog size={20}/>
                 </S.Link>

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -120,6 +120,7 @@ const CrewSetting = () => {
             )}
             {isCrewRuleOpen && (
                 <CrewRule
+                    crewData={crewData}
                     onClose={() => setIsCrewRuleOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { BsChevronRight } from "react-icons/bs";
 import Administrator from "./components/Administrator";
 import CrewActivity from "./components/CrewActivity";
@@ -10,9 +10,13 @@ import Delete from "./components/Delete";
 import LeaderTransfer from "./components/LeaderTransfer";
 import SettingBanner from "./components/SettingBanner";
 import * as S from "./Styles/CrewSetting.styles";
+import { useParams } from "react-router-dom";
+import { crewAPI } from "../../api";
 
 
 const CrewSetting = () => {
+    const { crewId } = useParams();
+    const [crewData, setCrewData] = useState();
     const [isSettingBannerOpen, setIsSettingBannerOpen] = useState(false);
     const [isCrewIntroOpen, setIsCrewIntroOpen] = useState(false);
     const [isCrewMemberOpen, setIsCrewMemberOpen] = useState(false);
@@ -22,11 +26,23 @@ const CrewSetting = () => {
     const [isAdministratorOpen, setIsAdministratorOpen] = useState(false);
     const [isLeaderTransferOpen, setIsLeaderTransferOpen] = useState(false);
     const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+    
+    const fetchCrewInfo = async () => {
+            try {
+                const response = await crewAPI.getCrewData(crewId);
+                setCrewData(response.data.data);
+            } catch (error) {
+                console.error("크루 정보 불러오기 실패", error);
+            }
+    }
+    useEffect(()=>{
+        fetchCrewInfo();
+    },[crewId]);
     return(
         <S.Container>
             <S.Setting>
                 <S.CrewName>
-                    <S.Title>초코러닝(초보자 코스 러닝)</S.Title>
+                    <S.Title>{crewData?.name}</S.Title>
                 </S.CrewName>
                 <S.MainTitle>
                     <S.Title>크루 기본 정보 관리</S.Title>
@@ -87,6 +103,7 @@ const CrewSetting = () => {
 
             {isSettingBannerOpen && (
                 <SettingBanner
+                    crewData={crewData}
                     onClose={() => setIsSettingBannerOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -114,6 +114,7 @@ const CrewSetting = () => {
             )}
             {isCrewMemberOpen && (
                 <CrewMember
+                    crewData={crewData}
                     onClose={() => setIsCrewMemberOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/components/CrewMember.jsx
+++ b/src/pages/CrewSetting/components/CrewMember.jsx
@@ -8,6 +8,7 @@ const CrewMember = ({ crewData, onClose }) => {
     const { crewId } = useParams();
     const [minNumber, setMinNumber] = useState(crewData?.minMembers);
     const [maxNumber, setMaxNumber] = useState(crewData?.maxMembers);
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -17,22 +18,19 @@ const CrewMember = ({ crewData, onClose }) => {
     const handleMinNumber = (e) => setMinNumber(e.target.value);
     const handleMaxNumber = (e) => setMaxNumber(e.target.value);
 
+    // 변경된 필드만 submit
     const handleSubmit = async() => {
         const submitData = {};
         if(minNumber !== crewData.minMembers){
-            console.log(minNumber, "vs",crewData.minMembers);
             submitData.minMembers = Number(minNumber);
         }
         if(maxNumber !== crewData.maxMembers){
-            console.log(maxNumber, "vs",crewData.maxMembers);
             submitData.maxMembers = Number(maxNumber);
         }
         const formData = new FormData();
         formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
         try {
-            console.log("submitData: ", submitData);
             const response = await crewAPI.updateCrewData(crewId, formData);
-            console.log(response.data);
         } catch (error) {
             console.log("변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewMember.jsx
+++ b/src/pages/CrewSetting/components/CrewMember.jsx
@@ -1,10 +1,40 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { useState } from "react";
+import { crewAPI } from "../../../api";
+import { useParams } from "react-router-dom";
 
-const CrewMember = ({ onClose }) => {
+const CrewMember = ({ crewData, onClose }) => {
+    const { crewId } = useParams();
+    const [minNumber, setMinNumber] = useState(crewData?.minMembers);
+    const [maxNumber, setMaxNumber] = useState(crewData?.maxMembers);
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
+        }
+    }
+    
+    const handleMinNumber = (e) => setMinNumber(e.target.value);
+    const handleMaxNumber = (e) => setMaxNumber(e.target.value);
+
+    const handleSubmit = async() => {
+        const submitData = {};
+        if(minNumber !== crewData.minMembers){
+            console.log(minNumber, "vs",crewData.minMembers);
+            submitData.minMembers = Number(minNumber);
+        }
+        if(maxNumber !== crewData.maxMembers){
+            console.log(maxNumber, "vs",crewData.maxMembers);
+            submitData.maxMembers = Number(maxNumber);
+        }
+        const formData = new FormData();
+        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
+        try {
+            console.log("submitData: ", submitData);
+            const response = await crewAPI.updateCrewData(crewId, formData);
+            console.log(response.data);
+        } catch (error) {
+            console.log("변경 실패", error);
         }
     }
 
@@ -33,19 +63,29 @@ const CrewMember = ({ onClose }) => {
                         <S.NumberContainer>
                             {/*멤버수 값 받아야 합니다. */}
                             <S.TextItem>최소</S.TextItem>
-                            <S.SetNumber type="number"/>
+                            <S.SetNumber 
+                                type="number"
+                                min={2}
+                                value={minNumber}
+                                onChange={handleMinNumber}
+                            />
                             <S.TextItem>명</S.TextItem>
                         </S.NumberContainer>
                         <S.TextItem>~</S.TextItem>
                         <S.NumberContainer>
                             <S.TextItem>최대</S.TextItem>
-                            <S.SetNumber type="number"/>
+                            <S.SetNumber
+                                type="number"
+                                max={30}
+                                value={maxNumber}
+                                onChange={handleMaxNumber}
+                            />
                             <S.TextItem>명</S.TextItem>
                         </S.NumberContainer>
                     </S.NumberSetting>
                 </S.SettingContainer>
                 <S.ButtonContainer style={{ marginTop: '40px' }}>
-                        <S.CompletionButton>
+                        <S.CompletionButton onClick={handleSubmit}>
                             수정완료
                         </S.CompletionButton>
                         <S.CancelButton onClick={onClose}>

--- a/src/pages/CrewSetting/components/CrewRule.jsx
+++ b/src/pages/CrewSetting/components/CrewRule.jsx
@@ -13,50 +13,44 @@ const CrewRule = ({ crewData, onClose }) => {
     const [maxAge, setMaxAge] = useState(crewData?.maxAge);
    
     const handlePanelClick = (e) => {
-        console.log(crewData);
         if(e.target === e.currentTarget){
             onClose();
         }
     }
 
-    const handleGender = (e) => {
-        setGender(e.target.value);
-        console.log(e.target.value);
-    };
+    const handleGender = (e) => setGender(e.target.value);
     const handleMinAge = (e) => setMinAge(e.target.value);
     const handleMaxAge = (e) => setMaxAge(e.target.value);
+
+    // 변경된 필드만 submit
     const handleSubmit = async() => {
         const submitData = {};
         if(gender !== crewData.genderRestriction){
-            console.log(gender, "vs",crewData.genderRestriction);
             if(gender !== "none"){
                 submitData.genderRestriction = gender;
             }else{
-                submitData.genderRestriction = null;
+                submitData.genderRestriction = null;  // 제한없음인 경우 null 값 전달
             }
         }
         if(minAge !== crewData.minAge){
-            console.log(minAge, "vs",crewData.minAge);
             if(minAge !== ''){
                 submitData.minAge = Number(minAge);
             }else{
-                submitData.minAge = null;
+                submitData.minAge = null;  // 제한없음인 경우 null 값 전달
             }
         }
         if(maxAge !== crewData.maxAge){
-            console.log(maxAge, "vs",crewData.maxAge);
             if(maxAge !== ''){
                 submitData.maxAge = Number(maxAge);
             }else{
-                submitData.maxAge = null;
+                submitData.maxAge = null;  // 제한없음인 경우 null 값 전달
             }
         }
         const formData = new FormData();
         formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
         try {
-            console.log("submitData: ", submitData);
+            // console.log("submitData: ", submitData);
             const response = await crewAPI.updateCrewData(crewId, formData);
-            console.log(response.data);
         } catch (error) {
             console.log("변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewRule.jsx
+++ b/src/pages/CrewSetting/components/CrewRule.jsx
@@ -1,13 +1,80 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { useEffect, useState } from "react";
+import { crewAPI } from "../../../api";
+import { useParams } from "react-router-dom";
 
 
-const CrewRule = ({ onClose }) => {
+const CrewRule = ({ crewData, onClose }) => {
+    const { crewId } = useParams();
+    const [initialGender, setInitialGender] = useState("");
+    const [gender, setGender] = useState("");
+    const [minAge, setMinAge] = useState(crewData?.minAge);
+    const [maxAge, setMaxAge] = useState(crewData?.maxAge);
+   
     const handlePanelClick = (e) => {
+        console.log(crewData);
         if(e.target === e.currentTarget){
             onClose();
         }
     }
+
+    const handleGender = (e) => {
+        setGender(e.target.value);
+        console.log(e.target.value);
+    };
+    const handleMinAge = (e) => setMinAge(e.target.value);
+    const handleMaxAge = (e) => setMaxAge(e.target.value);
+    const handleSubmit = async() => {
+        const submitData = {};
+        if(gender !== crewData.genderRestriction){
+            console.log(gender, "vs",crewData.genderRestriction);
+            if(gender !== "none"){
+                submitData.genderRestriction = gender;
+            }else{
+                submitData.genderRestriction = null;
+            }
+        }
+        if(minAge !== crewData.minAge){
+            console.log(minAge, "vs",crewData.minAge);
+            if(minAge !== ''){
+                submitData.minAge = Number(minAge);
+            }else{
+                submitData.minAge = null;
+            }
+        }
+        if(maxAge !== crewData.maxAge){
+            console.log(maxAge, "vs",crewData.maxAge);
+            if(maxAge !== ''){
+                submitData.maxAge = Number(maxAge);
+            }else{
+                submitData.maxAge = null;
+            }
+        }
+        const formData = new FormData();
+        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
+        try {
+            console.log("submitData: ", submitData);
+            const response = await crewAPI.updateCrewData(crewId, formData);
+            console.log(response.data);
+        } catch (error) {
+            console.log("변경 실패", error);
+        }
+    }
+
+    // 기존 크루 성별제한 확인
+    useEffect(()=>{
+        if(crewData.genderRestriction == null){
+            setInitialGender("none");
+        }else{
+            setInitialGender(crewData.genderRestriction);
+        }
+        setGender(initialGender=> initialGender);
+    },[]);
+
+    useEffect(()=>{
+        setGender(initialGender);
+    },[initialGender]);
 
     return (
         <S.Panel onClick={handlePanelClick}>
@@ -35,13 +102,11 @@ const CrewRule = ({ onClose }) => {
                             style={{
                                 marginBottom: '0',
                             }}
-                            onChange={(e) => {
-                                // API 호출을 위한 상태 업데이트 로직 추가 예정
-                                console.log('선택된 값:', e.target.value);
-                            }}
+                            value={gender}
+                            onChange={handleGender}
                         >
-                            <option value="male">남자만</option>
-                            <option value="female">여자만</option>
+                            <option value="M">남자만</option>
+                            <option value="F">여자만</option>
                             <option value="none">제한없음</option>
                         </S.Select>
                     </S.RuleContainer>
@@ -50,13 +115,25 @@ const CrewRule = ({ onClose }) => {
                     </S.SettingTitle>
                     <S.NumberSetting>
                         <S.TextItem>최소</S.TextItem>
-                        <S.SetNumber/>
+                        <S.SetNumber
+                            type="number"
+                            min={0}
+                            max={maxAge}
+                            value={minAge}
+                            onChange={handleMinAge}
+                        />
                         <S.TextItem>~</S.TextItem>
                         <S.TextItem>최대</S.TextItem>
-                        <S.SetNumber/>
+                        <S.SetNumber
+                            type="number"
+                            min={minAge}
+                            max={100}
+                            value={maxAge}
+                            onChange={handleMaxAge}
+                        />
                     </S.NumberSetting>
                     <S.ButtonContainer style={{ marginTop: '40px' }}>
-                        <S.CompletionButton>
+                        <S.CompletionButton onClick={handleSubmit}>
                             수정완료
                         </S.CompletionButton>
                         <S.CancelButton onClick={onClose}>

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -8,6 +8,7 @@ const SettingBanner = ({ crewData, onClose }) => {
     const { crewId } = useParams();
     const [updatedName, setUpdatedName] = useState(crewData?.name);
     const [bgImg, setBgImg] = useState();
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -17,18 +18,17 @@ const SettingBanner = ({ crewData, onClose }) => {
     const handleCrewName = (e) => {
         setUpdatedName(e.target.value);
     }
+    // 변경된 필드만 submit
     const handleSubmit = async() => {
         const submitData = {};
         if(updatedName !== crewData.name){
-            console.log(updatedName, "vs",crewData.name);
             submitData.name = updatedName;
         }
         const formData = new FormData();
         formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
         try {
-            console.log("submitData: ", submitData);
+            // console.log("submitData: ", submitData);
             const response = await crewAPI.updateCrewData(crewId, formData);
-            console.log(response.data);
         } catch (error) {
             console.log("변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -18,13 +18,13 @@ const SettingBanner = ({ crewData, onClose }) => {
         setUpdatedName(e.target.value);
     }
     const handleSubmit = async() => {
-        const submitData = {}
+        const submitData = {};
         if(updatedName !== crewData.name){
-            console.log(updatedName, crewData.name);
+            console.log(updatedName, "vs",crewData.name);
             submitData.name = updatedName;
         }
         const formData = new FormData();
-        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "multipart/form-data" }));
+        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
         try {
             console.log("submitData: ", submitData);
             const response = await crewAPI.updateCrewData(crewId, formData);

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -1,10 +1,36 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { useState } from "react";
+import { crewAPI } from "../../../api";
+import { useParams } from "react-router-dom";
 
-const SettingBanner = ({ onClose }) => {
+const SettingBanner = ({ crewData, onClose }) => {
+    const { crewId } = useParams();
+    const [updatedName, setUpdatedName] = useState(crewData?.name);
+    const [bgImg, setBgImg] = useState();
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
+        }
+    }
+
+    const handleCrewName = (e) => {
+        setUpdatedName(e.target.value);
+    }
+    const handleSubmit = async() => {
+        const submitData = {}
+        if(updatedName !== crewData.name){
+            console.log(updatedName, crewData.name);
+            submitData.name = updatedName;
+        }
+        const formData = new FormData();
+        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "multipart/form-data" }));
+        try {
+            console.log("submitData: ", submitData);
+            const response = await crewAPI.updateCrewData(crewId, formData);
+            console.log(response.data);
+        } catch (error) {
+            console.log("변경 실패", error);
         }
     }
 
@@ -24,7 +50,9 @@ const SettingBanner = ({ onClose }) => {
                     {/* 크루명 변경 기능 */}
                     <S.CrewNameInput
                         type="text"
+                        value={updatedName}
                         placeholder="크루명을 입력해주세요"
+                        onChange={handleCrewName}
                     />
                     <S.BannerImageContainer>
                         {/* 배너 이미지 변경 기능 */}
@@ -38,6 +66,7 @@ const SettingBanner = ({ onClose }) => {
                                         const reader = new FileReader();
                                         reader.onloadend = () => {
                                             console.log("이미지가 선택되었습니다:", reader.result);
+                                            setBgImg(reader.result);
                                         };
                                         reader.readAsDataURL(file);
                                     }
@@ -51,7 +80,8 @@ const SettingBanner = ({ onClose }) => {
                                     width: "100%",
                                     height: "100%",
                                     cursor: "pointer",
-                                    display: "block"
+                                    display: "block",
+                                    backgroundImage: `url(${bgImg})`
                                 }}
                             >
                             </label>
@@ -59,7 +89,7 @@ const SettingBanner = ({ onClose }) => {
                     </S.BannerImageContainer>
                 </S.SettingContainer>
                 <S.ButtonContainer>
-                    <S.CompletionButton>
+                    <S.CompletionButton onClick={() => handleSubmit()}>
                         수정완료
                     </S.CompletionButton>
                     <S.CancelButton onClick={onClose}>


### PR DESCRIPTION
## 구현내용
### 크루설정 기능
- 크루명 변경 API 구현
- 크루 최소,최대 멤버 수 변경 API 구현
- 크루 성별제한 및 나이제한 설정 변경 API 구현

### 테스트 항목
- [x] 이름 변경 후 새로고침하여 확인
- [x] 최소 멤버 수 변경 후 새로고침하여 확인
- [x] 최대 멤버 수 변경 후 새로고침하여 확인
- [x] 최소 멤버 수 2명 이하, 최대 멤버 수 30명 이상 안되도록 확인
- [x] 성별 제한 남성만/여성만 변경 후 새로고침하여 확인
- [x] 최소 나이 제한 설정 변경 후 새로고침하여 확인
- [x] 최대 나이 제한 설정 변경 후 새로고침하여 확인
- [x] 최소/최대 나이가 최대/최소 나이보다 작/크도록 되는지 확인
- [ ] 성별 제한 null 값 적용되는지 확인
- [ ] 최소 나이 null 값 적용되는지 확인
- [ ] 최대 나이 null 값 적용되는지 확인

### 추가 고려사항
- 변경 후 페이지 리렌더링: `현재는 새로고침해야만 변경사항 적용됨`
- 관리자만 변경 권한 부여
- 🚨 나이/성별 필드를 제한없음으로 변경 시 `null` 값 전송하고 있지만 반영되지 않음 (백엔드와 의논 후 추후 수정)
- 최소/최대 멤버 수 `2~30`만 되도록 확인했지만 직접 값 입력 시 `2~30`값이 벗어나는 것을 막을 수 없음 -> 유효성 검사 필요