### PR TITLE
feat: 크루 가입 요청 수락/거절 api 구현

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -115,7 +115,7 @@ export const crewAPI = {
     uploadImage: (formData, config) => api.post('/crews/images', formData, config),
     createIntro: (data) => api.post('/crews', data),
     getMyCrewList: () => api.get('/crews/me'),
-
+    // update api
     updateCrewBasicData: (crewId, formData) => api.patch(`/${crewId}/basic`, formData, {
         headers: {
             "Content-Type": "multipart/form-data",
@@ -124,9 +124,11 @@ export const crewAPI = {
     updateCrewIntro: (crewId, data) => api.patch(`/crews/${crewId}/report`, data),
     updateCrewHeadCount: (crewId, data) => api.patch(`/crews/${crewId}/headcount`, data),
     updateCrewRestriction: (crewId, data) => api.patch(`/crews/${crewId}/condition`, data),
-    
+    // join api
     requestsCrewJoin: (crewId, userId) => api.post(`/crews/${crewId}/join-requests`, userId),
     getReqJoinUserList: (crewId) => api.get(`/crews/${crewId}/join-requests`),
+    acceptJoinReq: (crewId, joinRequestId) => api.post(`/crews/${crewId}/join-requests/${joinRequestId}/accept`),
+    rejectJoinReq: (crewId, joinRequestId) => api.post(`/crews/${crewId}/join-requests/${joinRequestId}/reject`),
 };
 export const crewMembersAPI = {
     getMemberList: (crewId) => api.get(`/crews/${crewId}/members`),

--- a/src/api.js
+++ b/src/api.js
@@ -126,6 +126,7 @@ export const crewAPI = {
     updateCrewRestriction: (crewId, data) => api.patch(`/crews/${crewId}/condition`, data),
     
     requestsCrewJoin: (crewId, userId) => api.post(`/crews/${crewId}/join-requests`, userId),
+    getReqJoinUserList: (crewId) => api.get(`/crews/${crewId}/join-requests`),
 };
 export const crewMembersAPI = {
     getMemberList: (crewId) => api.get(`/crews/${crewId}/members`),

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -132,7 +132,6 @@ const CrewSetting = () => {
             )}
             {isJoinReqListOpen && (
                 <JoinReqList
-                    crewData={crewData}
                     onClose={() => setIsJoinReqListOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -12,6 +12,7 @@ import SettingBanner from "./components/SettingBanner";
 import * as S from "./Styles/CrewSetting.styles";
 import { useParams } from "react-router-dom";
 import { crewAPI } from "../../api";
+import JoinReqList from "./components/JoinReqList";
 
 
 const CrewSetting = () => {
@@ -21,6 +22,7 @@ const CrewSetting = () => {
     const [isCrewIntroOpen, setIsCrewIntroOpen] = useState(false);
     const [isCrewMemberOpen, setIsCrewMemberOpen] = useState(false);
     const [isCrewRuleOpen, setIsCrewRuleOpen] = useState(false);
+    const [isJoinReqListOpen, setIsJoinReqListOpen] = useState(false);
     const [isCrewActivityOpen, setIsCrewActivityOpen] = useState(false);
     const [isCrewScheduleOpen, setIsCrewScheduleOpen] = useState(false);
     const [isAdministratorOpen, setIsAdministratorOpen] = useState(false);
@@ -68,6 +70,10 @@ const CrewSetting = () => {
                     <S.Button onClick={() => setIsCrewRuleOpen(true)}><BsChevronRight/></S.Button>
                     {/* 설정한 조건 출력 */}
                     {/* <S.Desc>성별 제한없음, 나이 제한없음</S.Desc> */}
+                </S.SubTitle>
+                <S.SubTitle>
+                    <S.Title>가입 요청 목록 조회</S.Title>
+                    <S.Button onClick={() => setIsJoinReqListOpen(true)}><BsChevronRight/></S.Button>
                 </S.SubTitle>
                 <S.MainTitle>
                     <S.Title>멤버 활동 관리</S.Title>
@@ -122,6 +128,12 @@ const CrewSetting = () => {
                 <CrewRule
                     crewData={crewData}
                     onClose={() => setIsCrewRuleOpen(false)}
+                />
+            )}
+            {isJoinReqListOpen && (
+                <JoinReqList
+                    crewData={crewData}
+                    onClose={() => setIsJoinReqListOpen(false)}
                 />
             )}
             {isCrewActivityOpen && (

--- a/src/pages/CrewSetting/Styles/CrewSetting.styles.js
+++ b/src/pages/CrewSetting/Styles/CrewSetting.styles.js
@@ -213,6 +213,21 @@ export const Select = styled.select`
     outline: none;
     margin-bottom: 20px;
 `;
+// JoinReqList.jsx
+export const SectionContainer = styled.div`
+    display: flex;
+`;
+export const DecisionButton = styled.div`
+    background: none;
+    border: none;
+    font-size: 14px;
+    cursor: pointer;
+    color: #fff;
+    background: #352EAE;
+    border-radius: 5px;
+    padding: 5px 10px;
+    margin-left: 20px;
+`;
 
 // CrewActivity.jsx
 

--- a/src/pages/CrewSetting/components/JoinReqList.jsx
+++ b/src/pages/CrewSetting/components/JoinReqList.jsx
@@ -1,0 +1,104 @@
+import { AiOutlineClose } from "react-icons/ai";
+import * as S from "../Styles/CrewSetting.styles";
+import { useState, useRef, useEffect } from "react";
+
+const JoinReqList = ({ crewData, onClose }) => {
+    const handlePanelClick = (e) => {
+        if(e.target === e.currentTarget){
+            onClose();
+        }
+    }
+
+    // 멤버 api를 불러와 리더와 멤버를 비교
+    // 리더외엔 탈퇴버튼 표시
+    const members = Array.from({ length: 20 }, (_, index) => ({
+        id: index,
+        name: `김멤버`,
+        role: index === 0 ? '리더' : '', // 첫 번째 멤버(index가 0)일 때만 '리더'로 설정
+    }));
+
+    const [visibleMembers, setVisibleMembers] = useState(3);
+    const observerRef = useRef();
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if(entries[0].isIntersecting && visibleMembers < members.length){
+                    setVisibleMembers(prev => prev + 3);
+                }
+            },
+            { threshold: 0.5 }
+        );
+
+        if(observerRef.current){
+            observer.observe(observerRef.current);
+        }
+
+        return () => observer.disconnect();
+    }, [visibleMembers, members.length]);
+
+
+    return (
+        <S.Panel onClick={handlePanelClick}>
+            <S.BannerContainer onClick={(e) => e.stopPropagation()}
+                style={{
+                    width: "560px",
+                    right: "35%",
+                }}
+            >
+                <S.DeleteContainer>
+                    <S.SettingTitle>
+                        가입 요청 목록 조회
+                    </S.SettingTitle>
+                    <S.CloseButton onClick={onClose}>
+                        <AiOutlineClose size={24}/>
+                    </S.CloseButton>
+                </S.DeleteContainer>
+                <S.SettingContainer
+                    style={{
+                        maxHeight: "380px",
+                        overflow: "auto",
+                        msOverflowStyle: "none",
+                        scrollbarWidth: "none",
+                        margin: "20px 0",
+                        "&::-webkit-scrollbar": {
+                            display: "none"
+                        }
+                    }}
+                >
+                    {members.slice(0, visibleMembers).map((member, index) => (
+                        <S.MemberSection
+                            key={index}
+                            style={{
+                                display:'flex',
+                                justifyContent:'space-between'
+                            }}
+                        >
+                            <S.SectionContainer style={{display: 'flex'}}>
+                                <S.ProfileImage />
+                                <S.Name style={{marginTop: '11px'}}>
+                                    {member.name}
+                                </S.Name>
+                            </S.SectionContainer>
+                            <S.SectionContainer>
+                                <S.DecisionButton>승낙</S.DecisionButton>
+                                <S.DecisionButton
+                                    style={{
+                                        color: 'red',
+                                        background: '#DEDFE7'
+                                    }}
+                                >거절</S.DecisionButton>
+                            </S.SectionContainer>
+                        </S.MemberSection>
+                    ))}
+                    {visibleMembers < members.length && (
+                        <div ref={observerRef}>
+                        </div>
+                    )}
+                </S.SettingContainer>
+            </S.BannerContainer>
+        </S.Panel>
+    );
+};
+
+export default JoinReqList;


### PR DESCRIPTION

`크루 가입 요청`을 관리하는 창이 없어서 `크루 설정 > 크루 가입 관리`에  `가입 요청 목록 조회`내역을 추가해 주었습니다.

<img width="856" alt="스크린샷 2025-02-27 오후 8 49 58" src="https://github.com/user-attachments/assets/6ffb58b3-51e4-4944-950d-ee6349d049f5" />

## 구현사항
- 가입 요청 목록 보기 API구현
- 가입 요청 수락 API 구현
- 가입 요청 거절 API 구현

## 테스트
- [x] 수락하면 requestStatus가 pending에서 accept로 변하는지 확인
- [x] 거절하면 requestStatus가 pending에서 reject로 변하는지 확인
- [ ] 거절 당한 후 가입하기 요청 시 pending으로 변하는지 확인
=> 다시 가입하기 요청 신청 시 "이미 해당 크루에 가입 요청을 했습니다" 상태가 되어서 재요청 불가합니다...
- [X] 가입요청 상태가 pending인 멤버만 목록 창에 뜨는지 확인
- [X] 가입 요청이 없는 경우 없다고 제대로 뜨는지 확인