### PR TITLE
feat: 크루 설정 페이지 API 구현

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -115,6 +115,7 @@ export const crewAPI = {
     uploadImage: (formData, config) => api.post('/crews/images', formData, config),
     createIntro: (data) => api.post('/crews', data),
     getMyCrewList: () => api.get('/crews/me'),
+    deleteCrew: (crewId) => api.delete(`/crews/${crewId}`),
     // update api
     updateCrewBasicData: (crewId, formData) => api.patch(`/${crewId}/basic`, formData, {
         headers: {

--- a/src/api.js
+++ b/src/api.js
@@ -135,7 +135,7 @@ export const crewMembersAPI = {
     kickoutMember: (crewId, memberId) => api.delete(`/crews/${crewId}/members/${memberId}`),
     manageSchPermission: (crewId, data) => api.patch(`/crews/${crewId}/schedules/permissions`, data),
     manageMemberRole: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/role`, data),
-    delegateLeader: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/leader`, data),
+    delegateLeader: (crewId, memberId) => api.patch(`/crews/${crewId}/members/${memberId}/leader`),
 }
 
 export const scheduleAPI = {

--- a/src/api.js
+++ b/src/api.js
@@ -132,6 +132,10 @@ export const crewAPI = {
 };
 export const crewMembersAPI = {
     getMemberList: (crewId) => api.get(`/crews/${crewId}/members`),
+    kickoutMember: (crewId, memberId) => api.delete(`/crews/${crewId}/members/${memberId}`),
+    manageSchedulePermission: (crewId, data) => api.patch(`/crews/${crewId}/schedules/permissions`, data),
+    manageMemberRole: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/role`, data),
+    delegateLeader: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/leader`, data),
 }
 
 export const scheduleAPI = {

--- a/src/api.js
+++ b/src/api.js
@@ -117,7 +117,7 @@ export const crewAPI = {
     getMyCrewList: () => api.get('/crews/me'),
     deleteCrew: (crewId) => api.delete(`/crews/${crewId}`),
     // update api
-    updateCrewBasicData: (crewId, formData) => api.patch(`/${crewId}/basic`, formData, {
+    updateCrewBasicData: (crewId, formData) => api.patch(`/crews/${crewId}/basic`, formData, {
         headers: {
             "Content-Type": "multipart/form-data",
         },

--- a/src/api.js
+++ b/src/api.js
@@ -133,7 +133,7 @@ export const crewAPI = {
 export const crewMembersAPI = {
     getMemberList: (crewId) => api.get(`/crews/${crewId}/members`),
     kickoutMember: (crewId, memberId) => api.delete(`/crews/${crewId}/members/${memberId}`),
-    manageSchedulePermission: (crewId, data) => api.patch(`/crews/${crewId}/schedules/permissions`, data),
+    manageSchPermission: (crewId, data) => api.patch(`/crews/${crewId}/schedules/permissions`, data),
     manageMemberRole: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/role`, data),
     delegateLeader: (crewId, memberId, data) => api.patch(`/crews/${crewId}/members/${memberId}/leader`, data),
 }

--- a/src/pages/CrewCreate/Components/BannerImageInput.jsx
+++ b/src/pages/CrewCreate/Components/BannerImageInput.jsx
@@ -16,10 +16,8 @@ export default function BannerImageInput({bannerImage, setBannerImage, handleIma
         fileInputRef.current?.click();
     }
     const handleBannerImageChange = (e) => {
-        console.log("handleImageChange 실행")
         const file = e.target.files[0];
         handleImageUpload(file);
-        console.log("handleImageUpload 실행")
     };
     
     return(

--- a/src/pages/CrewCreate/CrewCreate.jsx
+++ b/src/pages/CrewCreate/CrewCreate.jsx
@@ -95,8 +95,8 @@ export default function CrewCreate() {
         const formData = new FormData();
         formData.append("crewReqDto", new Blob([JSON.stringify(crewReqDto)], { type: "application/json" }));
 
-        console.log("crewReqDto: ",crewReqDto);
-        console.log("File to be uploaded:", bannerImageFile);
+        // console.log("crewReqDto: ",crewReqDto);
+        // console.log("File to be uploaded:", bannerImageFile);
 
         if (bannerImageFile) {
             formData.append("bannerImage", bannerImageFile);
@@ -105,20 +105,15 @@ export default function CrewCreate() {
         }
         
         try {
-            console.log("get하여 배너이미지 확인 :");
-            console.log(formData.get("bannerImage"));
+            // console.log("get하여 배너이미지 확인 :");
+            // console.log(formData.get("bannerImage"));
             const token = localStorage.getItem('token');
             const response = await axios.post('/crews', formData, {
                 headers: {
                     'Authorization': token,
                 }
             });
-            // if (response.status === 200 && !response.data.error) {
-            //     console.log('크루 생성 성공 :', response);
-            //     alert('크루 생성 성공');
-            // } else {
-            //     throw new Error(response.data.message || '알 수 없는 에러가 발생했습니다.');
-            // }
+            
             if (response.data.status === 200 && response.status === 200) {
                 alert('요청이 성공적으로 처리되었습니다.');
             } else if (response.data.status === 500 || response.status === 500) {

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -115,6 +115,7 @@ const CrewSetting = () => {
             )}
             {isCrewIntroOpen && (
                 <CrewIntro
+                    crewData={crewData}
                     onClose={() => setIsCrewIntroOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/CrewSetting.jsx
+++ b/src/pages/CrewSetting/CrewSetting.jsx
@@ -157,6 +157,7 @@ const CrewSetting = () => {
             )}
             {isDeleteOpen && (
                 <Delete
+                    setIsCrewActivityOpen={setIsCrewActivityOpen}
                     onClose={() => setIsDeleteOpen(false)}
                 />
             )}

--- a/src/pages/CrewSetting/Styles/CrewSetting.styles.js
+++ b/src/pages/CrewSetting/Styles/CrewSetting.styles.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import ReactQuill from 'react-quill';
 
 export const Container = styled.div`
     width:1024px;
@@ -163,6 +164,31 @@ export const BannerImage = styled.div`
 `;
 
 // CrewIntro.jsx
+
+export const EditContainer = styled.div`
+    width: 100%;
+    height: 450px;
+    /* background-color: white; */
+    position: relative;
+`;
+
+export const QuillStyled = styled(ReactQuill)`
+    height: 100%;
+    /* border: none; */
+    background-color: white;
+    position: absolute;
+    top: 60%;
+
+    .ql-container {
+        height: calc(100% - 42px); // 툴바 높이(42px) 제외
+    }
+    .ql-editor {
+        height: 100%;
+        overflow-y: auto;
+    }
+`;
+
+//CrewMember.jsx
 
 export const NumberContainer = styled.div`
     display: flex;

--- a/src/pages/CrewSetting/Styles/CrewSetting.styles.js
+++ b/src/pages/CrewSetting/Styles/CrewSetting.styles.js
@@ -167,7 +167,7 @@ export const BannerImage = styled.div`
 
 export const EditContainer = styled.div`
     width: 100%;
-    height: 450px;
+    height: 400px;
     /* background-color: white; */
     position: relative;
 `;
@@ -177,7 +177,8 @@ export const QuillStyled = styled(ReactQuill)`
     /* border: none; */
     background-color: white;
     position: absolute;
-    top: 60%;
+    top: 10%;
+    left: 15%;
 
     .ql-container {
         height: calc(100% - 42px); // 툴바 높이(42px) 제외

--- a/src/pages/CrewSetting/components/Administrator.jsx
+++ b/src/pages/CrewSetting/components/Administrator.jsx
@@ -21,7 +21,6 @@ const Administrator = ({ onClose }) => {
                 role: role
             }
             const response = crewMembersAPI.manageMemberRole(crewId, memberId, submitdata);
-            console.log("역할 변경 성공", response);
         } catch (error) {
             console.error("변경 실패",error);
         }

--- a/src/pages/CrewSetting/components/Administrator.jsx
+++ b/src/pages/CrewSetting/components/Administrator.jsx
@@ -21,6 +21,10 @@ const Administrator = ({ onClose }) => {
                 role: role
             }
             const response = crewMembersAPI.manageMemberRole(crewId, memberId, submitdata);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("변경 실패",error);
         }

--- a/src/pages/CrewSetting/components/CrewActivity.jsx
+++ b/src/pages/CrewSetting/components/CrewActivity.jsx
@@ -18,8 +18,6 @@ const CrewActivity = ({ onClose }) => {
     const handleKickOut = async(memberId) => {
         try {
             const response = await crewMembersAPI.kickoutMember(crewId, memberId);
-            // members에 memberId 값이 없어서 기능 작동은 안되는 중...
-            console.log("탈퇴",response);
         } catch (error) {
             console.error("탈퇴 실패", error);
         }
@@ -29,14 +27,13 @@ const CrewActivity = ({ onClose }) => {
         async function fetchMembers() {
             try {
                 const response = await crewMembersAPI.getMemberList(crewId);
-                // console.log(response.data.data);
                 setMembers(response.data.data);
             } catch (error) {
                 console.error("크루 멤버 읽기 실패", error);
             }
         }
         fetchMembers();
-    },[]);
+    },[members]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(
@@ -93,8 +90,7 @@ const CrewActivity = ({ onClose }) => {
                             <S.Role>{member.role}</S.Role>
                             {member.role !== 'LEADER' && (
                                 <S.CrewButton
-                                    // memberId 없어서 일단은 index값 넣어둠ㅎㅎ
-                                    onClick={() => handleKickOut(index)}
+                                    onClick={() => handleKickOut(member.memberId)}
                                 >탈퇴</S.CrewButton>
                             )}
                         </S.MemberSection>

--- a/src/pages/CrewSetting/components/CrewActivity.jsx
+++ b/src/pages/CrewSetting/components/CrewActivity.jsx
@@ -18,6 +18,10 @@ const CrewActivity = ({ onClose }) => {
     const handleKickOut = async(memberId) => {
         try {
             const response = await crewMembersAPI.kickoutMember(crewId, memberId);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("탈퇴 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewIntro.jsx
+++ b/src/pages/CrewSetting/components/CrewIntro.jsx
@@ -1,8 +1,29 @@
+import ImageResize from 'quill-image-resize';
+import React, { useMemo, useState } from "react";
+import { Quill } from 'react-quill';
+import 'react-quill/dist/quill.snow.css';
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 
 
-const CrewIntro = ({ onClose }) => {
+const CrewIntro = ({ crewData, onClose }) => {
+    const [content, setContent] = useState(crewData?.description);
+
+    const modules = {
+        toolbar: [
+            [{ 'font': [] }],
+            [{ 'header': [1, 2, 3, 4, 5, 6, false] }],
+            ['bold', 'italic', 'underline', 'strike','blockquote'],   // toggled buttons
+            ['link','image'],
+            [{ 'align': [] },{ 'color': [] }], // dropdown with defaults from theme
+            [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+            [{ 'indent': '-1'}, { 'indent': '+1' }],    // outdent/indent
+        ],
+        ImageResize: {
+            parchment: Quill.import('parchment')
+        }
+    }
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -13,14 +34,22 @@ const CrewIntro = ({ onClose }) => {
         <S.Panel onClick={handlePanelClick}>
             <S.BannerContainer onClick={(e) => e.stopPropagation()}
                 style={{
-                    width: '1024px',
-                    right: '23%',
+                    width: '950px',
+                    left: '25%',
                 }}
             >
                 <S.DeleteContainer>
                     <S.SettingTitle>
                         크루 소개 설정
                     </S.SettingTitle>
+                    <S.EditContainer>
+                        <S.QuillStyled
+                            value={content}      
+                            modules={modules}
+                            placeholder='크루 설명을 입력해 주세요 (20자 이상)'
+                            onChange={(e) => setContent(e)}
+                        />
+                    </S.EditContainer>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>

--- a/src/pages/CrewSetting/components/CrewIntro.jsx
+++ b/src/pages/CrewSetting/components/CrewIntro.jsx
@@ -4,9 +4,13 @@ import { Quill } from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { crewAPI } from '../../../api';
+import { useNavigate, useParams } from 'react-router-dom';
 
 
 const CrewIntro = ({ crewData, onClose }) => {
+    const { crewId } = useParams();
+    const navigate = useNavigate();
     const [content, setContent] = useState(crewData?.description);
 
     const modules = {
@@ -30,11 +34,30 @@ const CrewIntro = ({ crewData, onClose }) => {
         }
     }
 
+    const handleSubmit = async() => {
+        try {
+            const submitData = {
+                description: content,
+                category: crewData.category,
+                regions: crewData.regions,
+            }
+            const response = await crewAPI.updateCrewIntro(crewId, submitData);
+            if (response.data.status === 200) {
+                // 성공하면 crewHome으로 이동 후 새로고침
+                navigate(`/crews/${crewId}/crewHome`);
+                window.location.reload();
+            }
+        } catch (error) {
+            console.error("수정 실패", error);
+        }
+    }
     return (
         <S.Panel onClick={handlePanelClick}>
-            <S.BannerContainer onClick={(e) => e.stopPropagation()}
+            <S.BannerContainer
+                onClick={(e) => e.stopPropagation()}
                 style={{
                     width: '950px',
+                    height: '65%',
                     left: '25%',
                 }}
             >
@@ -42,18 +65,30 @@ const CrewIntro = ({ crewData, onClose }) => {
                     <S.SettingTitle>
                         크루 소개 설정
                     </S.SettingTitle>
-                    <S.EditContainer>
-                        <S.QuillStyled
-                            value={content}      
-                            modules={modules}
-                            placeholder='크루 설명을 입력해 주세요 (20자 이상)'
-                            onChange={(e) => setContent(e)}
-                        />
-                    </S.EditContainer>
                     <S.CloseButton onClick={onClose}>
                         <AiOutlineClose size={24}/>
                     </S.CloseButton>
                 </S.DeleteContainer>
+                <S.EditContainer>
+                    <S.QuillStyled
+                        value={content}
+                        modules={modules}
+                        placeholder='크루 설명을 입력해 주세요 (20자 이상)'
+                        onChange={(e) => setContent(e)}
+                    />
+                </S.EditContainer>
+                <S.ButtonContainer
+                    style={{
+                        margin: "60px",
+                    }}
+                >
+                    <S.CompletionButton onClick={() => handleSubmit()}>
+                        수정완료
+                    </S.CompletionButton>
+                    <S.CancelButton onClick={onClose}>
+                        취소
+                    </S.CancelButton>
+                </S.ButtonContainer>
             </S.BannerContainer>
         </S.Panel>
     );

--- a/src/pages/CrewSetting/components/CrewMember.jsx
+++ b/src/pages/CrewSetting/components/CrewMember.jsx
@@ -25,6 +25,10 @@ const CrewMember = ({ crewData, onClose }) => {
         };
         try {
             const response = await crewAPI.updateCrewHeadCount(crewId, submitData);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewRule.jsx
+++ b/src/pages/CrewSetting/components/CrewRule.jsx
@@ -44,6 +44,10 @@ const CrewRule = ({ crewData, onClose }) => {
         }
         try {
             const response = await crewAPI.updateCrewRestriction(crewId, submitData);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.log("변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewSchedule.jsx
+++ b/src/pages/CrewSetting/components/CrewSchedule.jsx
@@ -25,6 +25,10 @@ const CrewSchedule = ({ onClose }) => {
         }
         try {
             const response = await crewMembersAPI.manageSchPermission(crewId, SubmitData);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("권한 변경 실패", error);
         }

--- a/src/pages/CrewSetting/components/CrewSchedule.jsx
+++ b/src/pages/CrewSetting/components/CrewSchedule.jsx
@@ -1,11 +1,32 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { crewMembersAPI } from "../../../api";
+import { useParams } from "react-router-dom";
+import { useState } from "react";
 
 
 const CrewSchedule = ({ onClose }) => {
+    const { crewId } = useParams();
+    const [createRole, setCreateRole] = useState();
+    const [updateRole, setUpdateRole] = useState();
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
+        }
+    }
+    
+    const handleCreateRole = (e) => setCreateRole(e.target.value);
+    const handleUpdateRole = (e) => setUpdateRole(e.target.value);
+
+    const handleSubmit = async() => {
+        const SubmitData = {
+            createPermission: createRole,
+            updatePermission: updateRole
+        }
+        try {
+            const response = await crewMembersAPI.manageSchPermission(crewId, SubmitData);
+        } catch (error) {
+            console.error("권한 변경 실패", error);
         }
     }
 
@@ -29,23 +50,25 @@ const CrewSchedule = ({ onClose }) => {
                 <S.SettingContainer>
                     <S.SettingTitle>일정 등록 권한</S.SettingTitle>
                     <S.RuleContainer>
-                        <S.Select>
-                            <option value="leader">리더</option>
-                            <option value="manager">리더와 관리자</option>
-                            <option value="all">모두</option>
+                        <S.Select value={createRole} onChange={handleCreateRole}>
+                            <option selected disabled>등록 권한 설정</option>/
+                            <option value="LEADER">리더</option>
+                            <option value="ADMIN">리더와 관리자</option>
+                            <option value="MEMBER">모두</option>
                         </S.Select>
                     </S.RuleContainer>
                     <S.SettingTitle>일정 수정 권한</S.SettingTitle>
                     <S.RuleContainer style={{ marginTop: "20px" }}>
-                        <S.Select>
-                            <option value="leader">리더</option>
-                            <option value="manager">리더와 관리자</option>
-                            <option value="all">모두</option>
+                        <S.Select value={updateRole} onChange={handleUpdateRole}>
+                            <option selected disabled>수정 권한 설정</option>/
+                            <option value="LEADER">리더</option>
+                            <option value="ADMIN">리더와 관리자</option>
+                            <option value="MEMBER">모두</option>
                         </S.Select>
                     </S.RuleContainer>
                 </S.SettingContainer>
                 <S.ButtonContainer>
-                    <S.CompletionButton>
+                    <S.CompletionButton onClick={handleSubmit}>
                         수정완료
                     </S.CompletionButton>
                     <S.CancelButton onClick={onClose}>

--- a/src/pages/CrewSetting/components/Delete.jsx
+++ b/src/pages/CrewSetting/components/Delete.jsx
@@ -1,12 +1,13 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
 import { crewAPI, crewMembersAPI } from "../../../api";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import { useEffect, useState } from "react";
 
 
 const Delete = ({ setIsCrewActivityOpen, onClose }) => {
     const { crewId } = useParams();
+    const navigate = useNavigate();
     const [members, setMembers] = useState([]);
 
     const handlePanelClick = (e) => {
@@ -24,6 +25,7 @@ const Delete = ({ setIsCrewActivityOpen, onClose }) => {
         try {
             const response = await crewAPI.deleteCrew(crewId);
             console.log(response);
+            navigate("/crewList");
         } catch (error) {
             console.error("크루 삭제 실패", error);
         }

--- a/src/pages/CrewSetting/components/Delete.jsx
+++ b/src/pages/CrewSetting/components/Delete.jsx
@@ -1,13 +1,46 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { crewAPI, crewMembersAPI } from "../../../api";
+import { useParams } from "react-router-dom";
+import { useEffect, useState } from "react";
 
 
-const Delete = ({ onClose }) => {
+const Delete = ({ setIsCrewActivityOpen, onClose }) => {
+    const { crewId } = useParams();
+    const [members, setMembers] = useState([]);
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
         }
     }
+
+    const handleToActivity = () => {
+        onClose();
+        setIsCrewActivityOpen(true);
+    }
+
+    const handleDelete = async() => {
+        try {
+            const response = await crewAPI.deleteCrew(crewId);
+            console.log(response);
+        } catch (error) {
+            console.error("크루 삭제 실패", error);
+        }
+    }
+
+    useEffect(() => {
+        async function fetcheMembers() {
+            try {
+                const response = await crewMembersAPI.getMemberList(crewId);
+                console.log(response.data.data);
+                setMembers(response.data.data);
+            } catch (error) {
+                console.error("멤버리스트 불러오기 실패", error);
+            }
+        }
+        fetcheMembers();
+    },[])
 
     return (
         <S.Panel onClick={handlePanelClick}>
@@ -27,17 +60,37 @@ const Delete = ({ onClose }) => {
                     <S.SettingTitle style={{ color: "red" }}>
                         크루 삭제하기
                     </S.SettingTitle>
-                    <S.Warning>
-                        크루를 삭제하면 크루원들은 크루에서 탈퇴됩니다.
-                    </S.Warning>
-                    <S.ButtonContainer>
-                        <S.DeleteButton>
-                            크루 삭제
-                        </S.DeleteButton>
-                        <S.CancelButton onClick={onClose}>
-                            취소
-                        </S.CancelButton>
-                    </S.ButtonContainer>
+                    {/* 리더 제외 멤버가 아직 있을 때 표시 */}
+                    {members.length > 1 &&
+                        <>
+                            <S.Warning>
+                                크루를 삭제하려면 직접 모든 멤버를 강제탈퇴 시킨 후 진행해주세요.
+                            </S.Warning>
+                            <S.ButtonContainer>
+                                <S.CancelButton
+                                    onClick={handleToActivity}
+                                >
+                                    멤버 활동 관리 페이지로 이동
+                                </S.CancelButton>
+                            </S.ButtonContainer>
+                        </>
+                    }
+                    {/* 멤버가 리더만 남았을 때 삭제 메시지 표시 */}
+                    {members.length == 1 &&
+                        <>
+                            <S.Warning>
+                                정말로 크루를 삭제하시겠습니까?
+                            </S.Warning>
+                            <S.ButtonContainer>
+                                <S.DeleteButton onClick={handleDelete}>
+                                    크루 삭제
+                                </S.DeleteButton>
+                                <S.CancelButton onClick={onClose}>
+                                    취소
+                                </S.CancelButton>
+                            </S.ButtonContainer>
+                        </>
+                    }
                 </S.SettingContainer>
             </S.BannerContainer>
         </S.Panel>

--- a/src/pages/CrewSetting/components/JoinReqList.jsx
+++ b/src/pages/CrewSetting/components/JoinReqList.jsx
@@ -37,6 +37,10 @@ const JoinReqList = ({ onClose }) => {
                 const response = await crewAPI.getReqJoinUserList(crewId);
                 const joinReqList = response.data.data;
                 setReqMembers(joinReqList || []);
+                if (response.data.status === 200) {
+                    // 성공하면 새로고침
+                    window.location.reload();
+                }
             } catch (error) {
                 console.error("요청 불러오기 실패", error);
             }

--- a/src/pages/CrewSetting/components/JoinReqList.jsx
+++ b/src/pages/CrewSetting/components/JoinReqList.jsx
@@ -42,7 +42,7 @@ const JoinReqList = ({ onClose }) => {
             }
         }
         fetchJoinUserList();
-    },[]);
+    },[reqMembers]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/src/pages/CrewSetting/components/LeaderTransfer.jsx
+++ b/src/pages/CrewSetting/components/LeaderTransfer.jsx
@@ -1,13 +1,39 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { crewMembersAPI } from "../../../api";
 
 
 const LeaderTransfer = ({ onClose }) => {
+    const { crewId } = useParams();
+    const [members, setMembers] = useState([]);
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
         }
     }
+
+    const handleDelegate = async(memberId) => {
+        try {
+            const response = crewMembersAPI.delegateLeader(crewId, memberId);
+        } catch (error) {
+            console.error("리더 위임 실패", error);
+        }
+    }
+
+    useEffect(() => {
+        async function fetchMembers() {
+            try {
+                const response = await crewMembersAPI.getMemberList(crewId);
+                setMembers(response.data.data);
+            } catch (error) {
+                console.error("크루 멤버 읽기 실패", error);
+            }
+        }
+        fetchMembers();
+    },[]);
 
     return (
         <S.Panel onClick={handlePanelClick}>
@@ -27,33 +53,30 @@ const LeaderTransfer = ({ onClose }) => {
                 </S.DeleteContainer>
                 <S.SettingContainer>
                     <S.Attached>
-                        현재 리더는 김루피 입니다. <br/>
-                        리더를 위임하면 자신은 멤버로 강등됩니다.
+                        현재 리더는 "{members.filter(member => member.role == "LEADER")
+                            .map(data => data.nickname)}" 입니다.
+                        <br/>리더를 위임하면 자신은 멤버로 강등됩니다.
                     </S.Attached>
-                    <S.MemberSection>
-                        <S.ProfileImage />
-                        <S.Name>
-                            김멤버
-                        </S.Name>
-                        <S.Role>
-                            관리자
-                        </S.Role>
-                        <S.AdminButton>
-                            리더 위임
-                        </S.AdminButton>
-                    </S.MemberSection>
-                    <S.MemberSection>
-                        <S.ProfileImage />
-                        <S.Name>
-                            김멤버
-                        </S.Name>
-                        <S.Role>
-                            관리자
-                        </S.Role>
-                        <S.AdminButton>
-                            리더 위임
-                        </S.AdminButton>
-                    </S.MemberSection>
+                    {members.some(member => member.role == "ADMIN") ? (
+                        members.map(member => 
+                            member.role == "ADMIN" && (
+                            <S.MemberSection>
+                                <S.ProfileImage src={member.profileImage}/>
+                                <S.Name>
+                                    {member.nickname}
+                                </S.Name>
+                                <S.Role>
+                                    {member.role}
+                                </S.Role>
+                                <S.AdminButton onClick={() => handleDelegate(member.memberId)}>
+                                    리더 위임
+                                </S.AdminButton>
+                            </S.MemberSection>
+                        ))
+                    ):(
+                        <div style={{margin: "10px"}}>현재 크루에 관리자가 없습니다.</div>
+                    )
+                    }
                 </S.SettingContainer>
             </S.BannerContainer>
         </S.Panel>

--- a/src/pages/CrewSetting/components/LeaderTransfer.jsx
+++ b/src/pages/CrewSetting/components/LeaderTransfer.jsx
@@ -28,6 +28,10 @@ const LeaderTransfer = ({ onClose }) => {
             try {
                 const response = await crewMembersAPI.getMemberList(crewId);
                 setMembers(response.data.data);
+                if (response.data.status === 200) {
+                    // 성공하면 새로고침
+                    window.location.reload();
+                }
             } catch (error) {
                 console.error("크루 멤버 읽기 실패", error);
             }

--- a/src/pages/CrewSetting/components/SettingBanner.jsx
+++ b/src/pages/CrewSetting/components/SettingBanner.jsx
@@ -1,6 +1,6 @@
 import { AiOutlineClose } from "react-icons/ai";
 import * as S from "../Styles/CrewSetting.styles";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { crewAPI } from "../../../api";
 import { useParams } from "react-router-dom";
 
@@ -8,6 +8,7 @@ const SettingBanner = ({ crewData, onClose }) => {
     const { crewId } = useParams();
     const [updatedName, setUpdatedName] = useState(crewData?.name);
     const [bgImg, setBgImg] = useState();
+    const [imgURL, setImgURL] = useState(crewData?.bannerImage);
 
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
@@ -20,17 +21,21 @@ const SettingBanner = ({ crewData, onClose }) => {
     }
     // 변경된 필드만 submit
     const handleSubmit = async() => {
-        const submitData = {};
-        if(updatedName !== crewData.name){
-            submitData.name = updatedName;
-        }
+        const submitData = {
+            name: updatedName
+        };
         const formData = new FormData();
-        formData.append("crewReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
+        formData.append("crewNameReqDto", new Blob([JSON.stringify(submitData)], { type: "application/json" }));
+        formData.append("bannerImage", bgImg);
+        
         try {
-            // console.log("submitData: ", submitData);
-            const response = await crewAPI.updateCrewData(crewId, formData);
+            const response = await crewAPI.updateCrewBasicData(crewId, formData);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
-            console.log("변경 실패", error);
+            console.error("변경 실패", error);
         }
     }
 
@@ -63,10 +68,11 @@ const SettingBanner = ({ crewData, onClose }) => {
                                 onChange={(e) => {
                                     const file = e.target.files[0];
                                     if(file) {
+                                        setBgImg(file);
                                         const reader = new FileReader();
                                         reader.onloadend = () => {
-                                            console.log("이미지가 선택되었습니다:", reader.result);
-                                            setBgImg(reader.result);
+                                            // url 저장
+                                            setImgURL(reader.result);
                                         };
                                         reader.readAsDataURL(file);
                                     }
@@ -81,9 +87,21 @@ const SettingBanner = ({ crewData, onClose }) => {
                                     height: "100%",
                                     cursor: "pointer",
                                     display: "block",
-                                    backgroundImage: `url(${bgImg})`
+                                    backgroundSize: "cover",
+                                    backgroundPosition: "center"
                                 }}
                             >
+                                <img 
+                                    src={imgURL || crewData?.bannerImage}
+                                    backgroundSize="cover"
+                                    backgroundPosition="center"
+                                    style={{
+                                        width: "100%",
+                                        height: "100%",
+                                        backgroundSize: "cover",
+                                        backgroundPosition: "center"
+                                    }}
+                                />
                             </label>
                         </S.BannerImage>
                     </S.BannerImageContainer>


### PR DESCRIPTION
## 💻 구현내용 ( 크루 설정 페이지 )
### 📌 크루 기본 정보 관리
- 크루 이름 및 배너사진 설정 ( 이름 및 배너사진 모두 변경 시 수정 가능)
- 크루 소개 설정 ( 기존 작성 글 불러 온 상태에서 수정)
### 📌 크루 가입 관리
- 크루 멤버 수
- 가입 조건 설정 ( 제한없는 경우 빈 칸으로 냅두도록 설정)
### 📌 멤버 활동 관리 + 크루 일정 관리
- 멤버 탈퇴 설정
- 일정 등록/수정 권한 설정
### 📌 리더, 공동 관리자 관리 + 크루 삭제
- 공동 관리자 관리
- 리더 위임 ( 관리자만 멤버 리스트에 뜨도록 구현)
- 크루 삭제 ( 피그마대로 멤버 모두 탈퇴하고 삭제 가능하도록 설정 )

## ✅ 테스트
- [x] 크루명+배너사진 변경
- [x] 크루 소개 변경
- [x] 크루 멤버 수 변경
- [x] 가입 조건 변경( 성별, 나이 )
- [x] 멤버 탈퇴
- [ ] 일정 등록 권한 설정
- [ ] 일정 수정 권한 설정
- [x] 공동 관리자 설정 => 멤버를 관리자로 승격, 관리자를 멤버로 강등 기능
- [x] 리더 위임
- [ ] 크루삭제

## 🔍 추가 고려 사항
- 크루 삭제 에러 (백엔드 해결)
- 일정 등록/수정 권한 설정을 서버에 보내긴 하는데 crewData에 존재하지 않아 설정한 데이터를 불러올 수 없음 => 개선 필요