### PR TITLE
fix: 크루 설정 창 무한 요청 및 창 꺼짐 에러 해결

### DIFF
--- a/src/pages/CrewCreate/Components/CrewIntroEditor.jsx
+++ b/src/pages/CrewCreate/Components/CrewIntroEditor.jsx
@@ -94,6 +94,7 @@ export default function CrewIntroEditor({setInfoContent}) {
             // console.log('최종 srcArray: ',srcArray);
             // console.log('최종 urlArray', urlArray);
             setInfoContent(updateContent);
+            alert("저장되었습니다.");
 
         } catch (error) {
             console.error('Error details:', {

--- a/src/pages/CrewHome/CrewHome.jsx
+++ b/src/pages/CrewHome/CrewHome.jsx
@@ -24,6 +24,9 @@ export default function CrewHome() {
             const userId = userResponse.data.data.id;
             // requestJoin
             const requestJoin = await crewAPI.requestsCrewJoin(crewId, userId);
+            if (requestJoin.data.status === 200) {
+                alert("가입 요청이 되었습니다");
+            }
         } catch (error) {
             switch (error.response.data.code) {
                 case "CM002":

--- a/src/pages/CrewSetting/components/Administrator.jsx
+++ b/src/pages/CrewSetting/components/Administrator.jsx
@@ -22,25 +22,26 @@ const Administrator = ({ onClose }) => {
             }
             const response = crewMembersAPI.manageMemberRole(crewId, memberId, submitdata);
             if (response.data.status === 200) {
-                // 성공하면 새로고침
-                window.location.reload();
+                // 성공하면 멤버 목록 새로고침
+                fetchMembers();
             }
         } catch (error) {
             console.error("변경 실패",error);
         }
     }
 
-    useEffect(() => {
-        async function fetchMembers() {
-            try {
-                const response = await crewMembersAPI.getMemberList(crewId);
-                setMembers(response.data.data);
-            } catch (error) {
-                console.error("크루 멤버 읽기 실패", error);
-            }
+    const fetchMembers = async() => {
+        try {
+            const response = await crewMembersAPI.getMemberList(crewId);
+            setMembers(response.data.data);
+        } catch (error) {
+            console.error("크루 멤버 읽기 실패", error);
         }
+    }
+
+    useEffect(() => {
         fetchMembers();
-    },[members]);
+    },[]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/src/pages/CrewSetting/components/CrewActivity.jsx
+++ b/src/pages/CrewSetting/components/CrewActivity.jsx
@@ -9,6 +9,7 @@ const CrewActivity = ({ onClose }) => {
     const [members, setMembers] = useState([]);
     const [visibleMembers, setVisibleMembers] = useState(3);
     const observerRef = useRef();
+
     const handlePanelClick = (e) => {
         if(e.target === e.currentTarget){
             onClose();
@@ -19,25 +20,25 @@ const CrewActivity = ({ onClose }) => {
         try {
             const response = await crewMembersAPI.kickoutMember(crewId, memberId);
             if (response.data.status === 200) {
-                // 성공하면 새로고침
-                window.location.reload();
+                // 성공하면 멤버 목록 새로고침
+                fetchMembers()
             }
         } catch (error) {
             console.error("탈퇴 실패", error);
         }
     }
-
-    useEffect(() => {
-        async function fetchMembers() {
-            try {
-                const response = await crewMembersAPI.getMemberList(crewId);
-                setMembers(response.data.data);
-            } catch (error) {
-                console.error("크루 멤버 읽기 실패", error);
-            }
+    const fetchMembers = async() => {
+        try {
+            const response = await crewMembersAPI.getMemberList(crewId);
+            setMembers(response.data.data);
+        } catch (error) {
+            console.error("크루 멤버 읽기 실패", error);
         }
+    }
+    
+    useEffect(() => {
         fetchMembers();
-    },[members]);
+    },[]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/src/pages/CrewSetting/components/JoinReqList.jsx
+++ b/src/pages/CrewSetting/components/JoinReqList.jsx
@@ -19,6 +19,10 @@ const JoinReqList = ({ onClose }) => {
     const handleAccept = async(userId) => {
         try {
             const response = crewAPI.acceptJoinReq(crewId, userId);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("수락 실패", error);
         }
@@ -26,6 +30,10 @@ const JoinReqList = ({ onClose }) => {
     const handleReject = async(userId) => {
         try {
             const response = crewAPI.rejectJoinReq(crewId, userId);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("거절 실패", error);
         }
@@ -37,16 +45,12 @@ const JoinReqList = ({ onClose }) => {
                 const response = await crewAPI.getReqJoinUserList(crewId);
                 const joinReqList = response.data.data;
                 setReqMembers(joinReqList || []);
-                if (response.data.status === 200) {
-                    // 성공하면 새로고침
-                    window.location.reload();
-                }
             } catch (error) {
                 console.error("요청 불러오기 실패", error);
             }
         }
         fetchJoinUserList();
-    },[reqMembers]);
+    },[]);
 
     useEffect(() => {
         const observer = new IntersectionObserver(

--- a/src/pages/CrewSetting/components/LeaderTransfer.jsx
+++ b/src/pages/CrewSetting/components/LeaderTransfer.jsx
@@ -18,6 +18,10 @@ const LeaderTransfer = ({ onClose }) => {
     const handleDelegate = async(memberId) => {
         try {
             const response = crewMembersAPI.delegateLeader(crewId, memberId);
+            if (response.data.status === 200) {
+                // 성공하면 새로고침
+                window.location.reload();
+            }
         } catch (error) {
             console.error("리더 위임 실패", error);
         }
@@ -28,10 +32,6 @@ const LeaderTransfer = ({ onClose }) => {
             try {
                 const response = await crewMembersAPI.getMemberList(crewId);
                 setMembers(response.data.data);
-                if (response.data.status === 200) {
-                    // 성공하면 새로고침
-                    window.location.reload();
-                }
             } catch (error) {
                 console.error("크루 멤버 읽기 실패", error);
             }


### PR DESCRIPTION
## 📌 문제 상황
- 크루설정 창( 공동 관리자 창, 멤버 활동 관리 창 ) 무한 요청 에러 발생
- 특정 설정 창( 가입 요청 목록 조회 창, 리더 위임 창) 패널 열림과 동시에 꺼짐 현상 발생
<img width="433" alt="스크린샷 2025-03-16 오전 9 21 37" src="https://github.com/user-attachments/assets/620392b9-6e59-4345-92ee-e92db432922a" />

## 📌 해결법
>크루설정 창 무한 요청 에러
- 기존에는 `fetchMembers`를 `useEffect`를 사용하여 `members`(크루 멤버 목록)이 변경될 때만 실행하도록 설정
하지만 `members`가 계속 요청(?)이 되어서 무한 요청 에러가 발생하는 것으로 보임.
- 초기 렌더링(마운트)될 때 멤버 목록을 불러오는 것으로 변경
- `관리자 설정` 및 `멤버 탈퇴` 버튼 클릭 시에만 `fetchMembers` 호출되도록 변경
- 무한 요청 에러 상황 해결!
> 설정 창 패널 열림과 동시에 꺼짐 현상
- 멤버 초기 데이터 불러오기 요청 성공 시 `window.location.reload();` 창 새로고침을 해서 문제 발생( 창 새로고침 기능 위치 잘못 설정 )
- 가입 수락/거절 및 리더 위임 버튼 클릭 시에만 창 새로고침하도록 변경
- 패널 열림과 동시에 꺼짐 현상 해결!

## 📌 추가 자잘한 변경사항 정리
- CrewIntroEditor 컴포넌트에섯 크루 설명 내용 작성 중 저장했을 때 정장이 되었음을 alert창으로 보여줌
- CrewHome에서 가입 요청 시 가입 요청이 되었는지 확인을 할 수 없고 재클릭 시 이미 가입 요청을 했다고 뜸. => 가입 요청 클릭 시 가입 요청 되었다고 alert 창 띄움