### PR TITLE
feat: 채팅방 목록 페이지 구현(입장 여부에 따른 목록)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -214,6 +214,7 @@ export const archiveAPI = {
 export const ChatAPI = {
     createChatRoom: (data) => api.post('/chat-rooms', data),
     getChatRoomList: () => api.get('/chat-rooms'),
+    getCrewChatRoomList: (crewId) => api.get(`chat-rooms?crewId=${crewId}`),
     getChatRoom: (roomId) => api.get(`/chat-rooms/${roomId}`),
     getMyChatRoom: () => api.get(`/chat-rooms/me`),
     getChatRoomHistory: (roomId) => api.get(`/chat-rooms/${roomId}/history`),

--- a/src/pages/CrewChat/CrewChatList.jsx
+++ b/src/pages/CrewChat/CrewChatList.jsx
@@ -1,0 +1,27 @@
+import { useParams } from "react-router-dom";
+import * as S from "./Styles/CrewChat.styles";
+import { useState } from "react";
+
+export default function CrewChatList() {
+
+    return(
+        <S.Wrapper>
+            <S.TabBarContainer>
+                <S.TabBarItem>입장하지 않은 채팅방</S.TabBarItem>
+                <S.TabBarItem>입장한 채팅방</S.TabBarItem>
+            </S.TabBarContainer>
+            <S.RoomListContainer>
+                <S.ChatRoomContainer>
+                    {/* 채팅방 프로필 */}
+                    <S.ProfileContainer>
+                        <S.CrewProfile/>
+                        <S.ChatRoomName>크루명</S.ChatRoomName>
+                        <S.ChatMemNumbers>18</S.ChatMemNumbers>
+                    </S.ProfileContainer>
+                    {/* 입장버튼 */}
+                    <S.EnterButton>입장하기</S.EnterButton>
+                </S.ChatRoomContainer>
+            </S.RoomListContainer>
+        </S.Wrapper>
+    );
+}

--- a/src/pages/CrewChat/CrewChatList.jsx
+++ b/src/pages/CrewChat/CrewChatList.jsx
@@ -83,28 +83,47 @@ export default function CrewChatList() {
                 </S.TabBarItem>
             </S.TabBarContainer>
             <S.RoomListContainer>
-                {!isEnterRoomsClick && notMyChatRoomList.map(room => (
-                    <S.ChatRoomContainer>
-                        {/* 채팅방 프로필 */}
-                        <S.ProfileContainer>
-                            <S.CrewProfile src={room.bannerImage}/>
-                            <S.ChatRoomName>{room.name}</S.ChatRoomName>
-                            <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
-                        </S.ProfileContainer>
-                        {/* 입장버튼 */}
-                        <S.EnterButton>입장하기</S.EnterButton>
-                    </S.ChatRoomContainer>
-                ))}
-                {isEnterRoomsClick && myChatRoomList.map(room => (
-                    <S.ChatRoomContainer>
-                        {/* 채팅방 프로필 */}
-                        <S.ProfileContainer>
-                            <S.CrewProfile src={room.bannerImage}/>
-                            <S.ChatRoomName>{room.name}</S.ChatRoomName>
-                            <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
-                        </S.ProfileContainer>
-                    </S.ChatRoomContainer>
-                ))}
+                {/* 크루 채팅방이 아예 없으면 => 아직 채팅방이 개설되지 않았습니다! */}
+                {crewChatRoomList.length > 0 ? (
+                    !isEnterRoomsClick ? (
+                        // 노가입 채팅방 없으면 => 모든 채팅방에 입장하였습니다!
+                        notMyChatRoomList.length > 0 ? (
+                            notMyChatRoomList.map(room => (
+                                <S.ChatRoomContainer>
+                                    {/* 채팅방 프로필 */}
+                                    <S.ProfileContainer>
+                                        <S.CrewProfile src={room.bannerImage}/>
+                                        <S.ChatRoomName>{room.name}</S.ChatRoomName>
+                                        <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
+                                    </S.ProfileContainer>
+                                    {/* 입장버튼 */}
+                                    <S.EnterButton>입장하기</S.EnterButton>
+                                </S.ChatRoomContainer>
+                            ))
+                        ):(
+                            <S.DetailMsg>모든 채팅방에 입장하였습니다!</S.DetailMsg>
+                        )
+                        
+                    ):(
+                        // 가입 채팅방 없으면 => 입장한 채팅방이 없습니다!
+                        myChatRoomList.length > 0 ? (
+                            myChatRoomList.map(room => (
+                                <S.ChatRoomContainer>
+                                    {/* 채팅방 프로필 */}
+                                    <S.ProfileContainer>
+                                        <S.CrewProfile src={room.bannerImage}/>
+                                        <S.ChatRoomName>{room.name}</S.ChatRoomName>
+                                        <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
+                                    </S.ProfileContainer>
+                                </S.ChatRoomContainer>
+                            ))
+                        ):(
+                            <S.DetailMsg>입장한 채팅방이 없습니다!</S.DetailMsg>
+                        )
+                    )
+                ):(
+                    <S.DetailMsg>아직 채팅방이 개설되지 않았습니다!</S.DetailMsg>
+                )}
             </S.RoomListContainer>
         </S.Wrapper>
     );

--- a/src/pages/CrewChat/CrewChatList.jsx
+++ b/src/pages/CrewChat/CrewChatList.jsx
@@ -1,26 +1,66 @@
 import { useParams } from "react-router-dom";
 import * as S from "./Styles/CrewChat.styles";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { ChatAPI } from "../../api";
 
 export default function CrewChatList() {
+    const { crewId } = useParams();
+    const [chatRoomList, setCrewChatRoomList] = useState([]);
+    const [isEnterRoomsClick, setIsEnterRoomsClick] = useState(false);
+
+    const handleTab = () => {
+        setIsEnterRoomsClick(true);
+        console.log("tlfgod")
+    }
+    const fetchCrewChatRooms = async() => {
+        try {
+            const response = await ChatAPI.getCrewChatRoomList(crewId);
+            console.log("크루 채팅방 목록", response.data.data);
+            setCrewChatRoomList(response.data.data);
+        } catch (error) {
+            console.error("해당 크루 채팅방 목록 불러오기 실패", error);
+        }
+    }
+    
+    useEffect(()=>{
+        fetchCrewChatRooms();
+    },[]);
 
     return(
         <S.Wrapper>
             <S.TabBarContainer>
-                <S.TabBarItem>입장하지 않은 채팅방</S.TabBarItem>
-                <S.TabBarItem>입장한 채팅방</S.TabBarItem>
+                <S.TabBarItem
+                    onClick={()=>setIsEnterRoomsClick(false)}
+                    style={{
+                        color: isEnterRoomsClick ? "black" : "#fff",
+                        backgroundColor: isEnterRoomsClick ? "#fff" : "#352EAE",
+                    }}
+                >
+                    입장하지 않은 채팅방
+                </S.TabBarItem>
+                <S.TabBarItem
+                    onClick={()=>setIsEnterRoomsClick(true)}
+                    style={{
+                        color: isEnterRoomsClick ? "#fff" : "black",
+                        backgroundColor: isEnterRoomsClick ? "#352EAE" : "#fff",
+                    }}
+                >
+                    입장한 채팅방
+                </S.TabBarItem>
             </S.TabBarContainer>
             <S.RoomListContainer>
-                <S.ChatRoomContainer>
-                    {/* 채팅방 프로필 */}
-                    <S.ProfileContainer>
-                        <S.CrewProfile/>
-                        <S.ChatRoomName>크루명</S.ChatRoomName>
-                        <S.ChatMemNumbers>18</S.ChatMemNumbers>
-                    </S.ProfileContainer>
-                    {/* 입장버튼 */}
-                    <S.EnterButton>입장하기</S.EnterButton>
-                </S.ChatRoomContainer>
+                {!isEnterRoomsClick && chatRoomList.map(room => (
+                    <S.ChatRoomContainer>
+                        {/* 채팅방 프로필 */}
+                        <S.ProfileContainer>
+                            <S.CrewProfile src={room.bannerImage}/>
+                            <S.ChatRoomName>{room.name}</S.ChatRoomName>
+                            <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
+                        </S.ProfileContainer>
+                        {/* 입장버튼 */}
+                        <S.EnterButton>입장하기</S.EnterButton>
+                    </S.ChatRoomContainer>
+                ))}
             </S.RoomListContainer>
         </S.Wrapper>
     );

--- a/src/pages/CrewChat/Styles/CrewChat.styles.js
+++ b/src/pages/CrewChat/Styles/CrewChat.styles.js
@@ -297,3 +297,7 @@ export const EnterButton = styled.div`
         background-color: #D4E3FB;
     }
 `;
+
+export const DetailMsg = styled.div`
+    margin: 20px 50px;
+`;

--- a/src/pages/CrewChat/Styles/CrewChat.styles.js
+++ b/src/pages/CrewChat/Styles/CrewChat.styles.js
@@ -229,3 +229,74 @@ export const MessageTime = styled.div`
     font-size: 12px;
     color: #797979;
 `;
+
+// CrewChatList.jsx(플로팅 메뉴로 채팅리스트 이동)
+export const Wrapper = styled.div`
+    /* background-color: aqua; */
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+`;
+
+export const TabBarContainer = styled.div`
+    background-color: #fff;
+    border: none;
+    display: flex;
+    border-radius: 50px;
+    margin: 20px 0px 40px 0px;
+`;
+
+export const TabBarItem = styled.div`
+    padding: 10px 40px;
+    border: 1px solid red;
+    border-radius: 50px;
+    &:hover{
+        color: #fff;
+        background-color: #352EAE;
+    }
+`;
+
+export const RoomListContainer = styled.div`
+    width: 768px;
+    min-height: 300px;
+    background-color: #fff;
+    border: 1px solid #DEDFE7;
+    border-radius: 15px;
+    padding: 20px 0px;
+    margin-bottom: 100px;
+`;
+
+// export const CrewProfile
+export const ChatRoomContainer = styled.div`
+    display: flex;
+    margin: 10px 50px;
+    justify-content: space-between;
+    align-items: center;
+`;
+
+export const ProfileContainer = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+export const ChatRoomName = styled.div`
+    margin: 0px 15px;
+`;
+
+export const ChatMemNumbers = styled.div`
+    color: #929292;
+`;
+
+export const EnterButton = styled.div`
+    height: 40px;
+    padding: 10px 40px;
+    border: 1px solid red;
+    border-radius: 50px;
+    color: #fff;
+    background-color: #352EAE;
+    &:hover{
+        color: black;
+        background-color: #D4E3FB;
+    }
+`;

--- a/src/pages/CrewChat/Styles/CrewChat.styles.js
+++ b/src/pages/CrewChat/Styles/CrewChat.styles.js
@@ -62,7 +62,7 @@ export const CrewProfile = styled.img`
     height: 50px;
     margin: 10px;
     border-radius: 50%;
-    border: 1px solid red;
+    border: 1px solid #DEDFE7;
 `;
 
 export const RoomName = styled.div`
@@ -241,7 +241,7 @@ export const Wrapper = styled.div`
 
 export const TabBarContainer = styled.div`
     background-color: #fff;
-    border: none;
+    border: 1px solid #DEDFE7;
     display: flex;
     border-radius: 50px;
     margin: 20px 0px 40px 0px;
@@ -249,7 +249,6 @@ export const TabBarContainer = styled.div`
 
 export const TabBarItem = styled.div`
     padding: 10px 40px;
-    border: 1px solid red;
     border-radius: 50px;
     &:hover{
         color: #fff;
@@ -267,7 +266,6 @@ export const RoomListContainer = styled.div`
     margin-bottom: 100px;
 `;
 
-// export const CrewProfile
 export const ChatRoomContainer = styled.div`
     display: flex;
     margin: 10px 50px;
@@ -291,7 +289,6 @@ export const ChatMemNumbers = styled.div`
 export const EnterButton = styled.div`
     height: 40px;
     padding: 10px 40px;
-    border: 1px solid red;
     border-radius: 50px;
     color: #fff;
     background-color: #352EAE;

--- a/src/pages/CrewChat/components/ChatRoomList.jsx
+++ b/src/pages/CrewChat/components/ChatRoomList.jsx
@@ -60,14 +60,6 @@ export default function ChatRoomList({onClose}) {
             console.error("채팅방 목록 불러오기 실패", error);
         }
     }
-    const fetchCrewChatRooms = async() => {
-        try {
-            const response = await ChatAPI.getCrewChatRoomList(crewId);
-            console.log("크루 채팅방 목록", response.data.data);
-        } catch (error) {
-            console.error("해당 크루 채팅방 목록 불러오기 실패", error);
-        }
-    }
 
     useEffect(() => {
         // 멤버 목록
@@ -92,7 +84,6 @@ export default function ChatRoomList({onClose}) {
         fetchMyName();
         // 처음 렌더링될 때 채팅방 리스트 불러오기
         fetchChatRooms();
-        fetchCrewChatRooms();
     },[]);
 
     return(

--- a/src/pages/CrewChat/components/ChatRoomList.jsx
+++ b/src/pages/CrewChat/components/ChatRoomList.jsx
@@ -52,12 +52,20 @@ export default function ChatRoomList({onClose}) {
 
     // 크루 채팅방 목록 불러오기
     // 크루 생성(ChatRoomList.jsx) 및 크루 삭제(CrewChatRoom.jsx)할 때만 실행할 수 있도록 useEffect 외부로 빼주었음.
-        const fetchChatRooms = async() => {
+    const fetchChatRooms = async() => {
         try {
             const response = await ChatAPI.getMyChatRoom();
             setChatRooms(response.data.data);
         } catch (error) {
             console.error("채팅방 목록 불러오기 실패", error);
+        }
+    }
+    const fetchCrewChatRooms = async() => {
+        try {
+            const response = await ChatAPI.getCrewChatRoomList(crewId);
+            console.log("크루 채팅방 목록", response.data.data);
+        } catch (error) {
+            console.error("해당 크루 채팅방 목록 불러오기 실패", error);
         }
     }
 
@@ -84,6 +92,7 @@ export default function ChatRoomList({onClose}) {
         fetchMyName();
         // 처음 렌더링될 때 채팅방 리스트 불러오기
         fetchChatRooms();
+        fetchCrewChatRooms();
     },[]);
 
     return(

--- a/src/pages/CrewHome/CrewHome.jsx
+++ b/src/pages/CrewHome/CrewHome.jsx
@@ -7,8 +7,6 @@ import { authAPI, crewAPI, crewMembersAPI } from "../../api";
 
 export default function CrewHome() {
     const { crewId } = useParams();
-    const [members, setMembers] = useState({});
-    const [leader, setLeader] = useState({});
     const [isMember, setIsMember] = useState(false);
     const [crewData, setCrewData] = useState({
         region: '',
@@ -71,29 +69,17 @@ export default function CrewHome() {
                 const resCrewData = response.data.data;
                 const regions = resCrewData.regions.map(region => region.regionDepth2).join(', ');
                 setCrewData({
+                    ...resCrewData,
                     region: regions,
                     currentNum: resCrewData.memberCount,
-                    maxMembers: resCrewData.maxMembers,
                     crewIntro: resCrewData.description
                 });
-                
+                console.log(resCrewData);
             } catch (error) {
                 console.error("크루 읽기 실패", error);
             }
         }
-        // 크루 멤버 확인
-        async function fetchMembers() {
-            try {
-                const response = await crewMembersAPI.getMemberList(crewId);
-                const resMem = (response.data.data);
-                setMembers(resMem);
-                setLeader(resMem.find(member => member.role == "LEADER"));
-            } catch (error) {
-                console.error("크루 멤버 데이터 가져오기 실패");
-            }
-        }
         fetchCrewData();
-        fetchMembers();
     }, [crewId]);
 
     return(
@@ -103,10 +89,10 @@ export default function CrewHome() {
                     <CrewInfo>
                         <UserInfoContainer>
                             <Profile>
-                                <ProfileImage src={leader?.profileImage}/>
+                                <ProfileImage src={crewData.profileImage}/>
                                 <ProfileText>
                                     <UserPosition>리더</UserPosition>
-                                    <UserName>{leader?.nickname}</UserName>
+                                    <UserName>{crewData.leader}</UserName>
                                 </ProfileText>
                             </Profile>
                         </UserInfoContainer>

--- a/src/pages/CrewMain/components/FloatingMenu.jsx
+++ b/src/pages/CrewMain/components/FloatingMenu.jsx
@@ -13,7 +13,8 @@ export default function FloatingMenu() {
         "공지사항": "crewNotice",
         "커뮤니티": "crewCommunity",
         "크루활동": "crewActivity",
-        "일정": "crewSchedule"
+        "일정": "crewSchedule",
+        "채팅": "crewChatList"
     };
 
     const [selectedMenu, setSelectedMenu] = useState(() => {

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -20,6 +20,7 @@ import Setting from "../pages/CrewSetting/CrewSetting";
 import Home from "../pages/home/Home";
 import AddInfo from "../pages/Login/AddInfo";
 import Login from "../pages/Login/Login";
+import CrewChatList from "../pages/CrewChat/CrewChatList";
 
 const Router = () => {
     return(
@@ -41,6 +42,7 @@ const Router = () => {
                     <Route path="crewCommunity" element={<Community />} />
                     <Route path="crewCommunity/write" element={<WriteCommunity />} />
                     <Route path="crewCommunity/update/:feedId" element={<UpdateCommunity />} />
+                    <Route path="crewChatList" element={<CrewChatList />} />
                     <Route path="crewSetting" element={<Setting />} />
                 </Route>
                 <Route path="/crews/:crewId/crewSchedule" element={<CrewSchedule />} />


### PR DESCRIPTION
## 📌 채팅방 목록 기능
- 유저가 입장하지 않은 채팅방 목록 보여줌
- 유저가 입장한 채팅방 목록 보여줌
- 탭바로 `입장하지 않은 채팅방`에서 `입장한 채팅방` 선택 시 내부 정보가 바뀌도록 설정( 반대도 마찬가지 )
- 크루 채팅방 목록, 내 채팅방 목록(모든 크루) API를 활용하여 각 탭에 맞는 데이터 보여주도록 리스트 필터링

## 📌 자잘한 것
- 크루 홈에서 리더 프로필이랑 이름을 crewData 활용해서 재적용

## 🎨 UI/UX 개선
- 채팅 메뉴 들어갔을 때 초기에 입장하지 않은 채팅방 목록이 보이도록 설정
- 개설된 채팅방 없을 경우, 모든 채팅방에 입장한 경우, 입장한 채팅방이 없는 경우에
메시지 띄워서 채팅방 존재 상태를 쉽게 알 수 있도록 설정
- 채팅방 이름이 긴 경우도 있어서 기존 회의에서 정한 3열 방식 대신 그냥 목록형으로 설정했습니다.

## ✅ 테스트 항목
- [x]  개설된 채팅방 없을 경우, `아직 채팅방이 개설되지 않았습니다!` 멘트 잘 뜨는지.
- [x]  모든 채팅방에 입장한 경우, `모든 채팅방에 입장하였습니다!` 멘트 잘 뜨는지.
- [x]  입장한 채팅방이 없는 경우, `입장한 채팅방이 없습니다!` 멘트 잘 뜨는지.
- [x]  채팅방 목록 수가 3-4개가 넘어갈 경우, 스크롤이 아닌 흰 박스가 리스트 개수에 맞추어 잘 늘어나는지.

## 🔍 추가 고려사항
- 입장하기 버튼 기능 구현 안했습니다. 이후에 웹소켓 연결해야합니다.
- 채팅 플로팅 메뉴 접근 불가 설정해야합니다.(크루원들만 접근 가능) =>`아예 플로팅 메뉴에 안뜨도록 하는거였나요?`

## 💻 참고용 영상
https://github.com/user-attachments/assets/65282546-9326-4c8a-ae39-c775cc830125

