### PR TITLE
feat: 채팅방 목록에서 입장 웹소켓 연결 + 팝업채팅창 최근 메시지

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -217,8 +217,9 @@ export const ChatAPI = {
     getCrewChatRoomList: (crewId) => api.get(`chat-rooms?crewId=${crewId}`),
     getChatRoom: (roomId) => api.get(`/chat-rooms/${roomId}`),
     getMyChatRoom: () => api.get(`/chat-rooms/me`),
-    getChatRoomHistory: (roomId) => api.get(`/chat-rooms/${roomId}/history`),
-    deleteChatRoom: (roomId) => api.delete(`/chat-rooms/${roomId}`)
+    getChatRoomHistory: (roomId) => api.get(`/chat-rooms/${roomId}/chat`),
+    deleteChatRoom: (roomId) => api.delete(`/chat-rooms/${roomId}`),
+    getRoomRecentChat: (roomId) => api.get(`/chat-rooms/${roomId}/chat/recent`),
 }
 
 export default api;

--- a/src/hooks/useChat.jsx
+++ b/src/hooks/useChat.jsx
@@ -15,7 +15,7 @@ const useChat = (token, roomId) => {
         };
     }, []);
 
-    const connect = () => {
+    const connect = (roomId) => {
         if (!token || !roomId) {
             alert("토큰과 채팅방 ID를 입력하세요!");
             return;
@@ -44,7 +44,7 @@ const useChat = (token, roomId) => {
         }
     };
 
-    const enterChatRoom = () => {
+    const enterChatRoom = (roomId) => {
         if (!stompClient || !stompClient.connected) {
             alert("WebSocket에 먼저 연결하세요!");
             return;

--- a/src/pages/CrewChat/CrewChatList.jsx
+++ b/src/pages/CrewChat/CrewChatList.jsx
@@ -3,6 +3,7 @@ import * as S from "./Styles/CrewChat.styles";
 import { useEffect, useState } from "react";
 import { ChatAPI } from "../../api";
 import useChat from "../../hooks/useChat";
+import CrewChat from "./CrewChat";
 
 export default function CrewChatList() {
     const { crewId } = useParams();
@@ -19,6 +20,10 @@ export default function CrewChatList() {
             connect(roomId);
             enterChatRoom(roomId);
             disconnect();
+            // 내 채팅방 불러오기 -> myAllChatRoom데이터 리로드
+            // useEffect로 인해 filterIsEnterRoom함수 실행
+            // 화면에 뜨는 목록 변경!
+            fetchChatRooms();
         } catch (error) {
             console.error("채팅방 입장 중 오류 발생", error);
         }
@@ -27,7 +32,7 @@ export default function CrewChatList() {
     const fetchCrewChatRooms = async() => {
         try {
             const response = await ChatAPI.getCrewChatRoomList(crewId);
-            console.log("크루 채팅방 목록", response.data.data);
+            // console.log("크루 채팅방 목록", response.data.data);
             setCrewChatRoomList(response.data.data);
         } catch (error) {
             console.error("해당 크루 채팅방 목록 불러오기 실패", error);
@@ -37,7 +42,7 @@ export default function CrewChatList() {
     const fetchChatRooms = async() => {
         try {
             const response = await ChatAPI.getMyChatRoom();
-            console.log("내 채팅방", response.data.data);
+            // console.log("내 채팅방", response.data.data);
             setMyAllChatRoom(response.data.data);
         } catch (error) {
             console.error("채팅방 목록 불러오기 실패", error);
@@ -51,7 +56,7 @@ export default function CrewChatList() {
         const enteredCrewChatRoom = myAllChatRoom.filter(
             myRoom => crewChatRoomList.some(crewRoom => myRoom.roomId == crewRoom.roomId)
         );
-        console.log("enteredCrewChatRoom...", enteredCrewChatRoom);
+        // console.log("enteredCrewChatRoom...", enteredCrewChatRoom);
         setMyChatRoomList(enteredCrewChatRoom);
         
         // 입장하지 않은 채팅방
@@ -60,7 +65,7 @@ export default function CrewChatList() {
         const isntCrewChatRoom = crewChatRoomList.filter(
             crewRoom => !myChatRoomList.some(myRoom => myRoom.roomId == crewRoom.roomId)
         );
-        console.log("notMyChatRoomList...", isntCrewChatRoom);
+        // console.log("notMyChatRoomList...", isntCrewChatRoom);
         setNotMyChatRoomList(isntCrewChatRoom);
 
     }
@@ -76,6 +81,7 @@ export default function CrewChatList() {
 
     return(
         <S.Wrapper>
+            <CrewChat/>
             <S.TabBarContainer>
                 <S.TabBarItem
                     onClick={()=>setIsEnterRoomsClick(false)}

--- a/src/pages/CrewChat/CrewChatList.jsx
+++ b/src/pages/CrewChat/CrewChatList.jsx
@@ -2,6 +2,7 @@ import { useParams } from "react-router-dom";
 import * as S from "./Styles/CrewChat.styles";
 import { useEffect, useState } from "react";
 import { ChatAPI } from "../../api";
+import useChat from "../../hooks/useChat";
 
 export default function CrewChatList() {
     const { crewId } = useParams();
@@ -10,6 +11,18 @@ export default function CrewChatList() {
     const [myChatRoomList, setMyChatRoomList] = useState([]);
     const [notMyChatRoomList, setNotMyChatRoomList] = useState([]);
     const [isEnterRoomsClick, setIsEnterRoomsClick] = useState(false);
+    const token = localStorage.getItem('token')?.replace('Bearer ', ''); 
+    const { connect, disconnect, enterChatRoom } = useChat(token);
+    
+    const handleEnterRoom = async(roomId) => {
+        try {
+            connect(roomId);
+            enterChatRoom(roomId);
+            disconnect();
+        } catch (error) {
+            console.error("채팅방 입장 중 오류 발생", error);
+        }
+    }
 
     const fetchCrewChatRooms = async() => {
         try {
@@ -56,6 +69,7 @@ export default function CrewChatList() {
         fetchCrewChatRooms();
         fetchChatRooms();
     },[]);
+
     useEffect(()=>{
         filterIsEnterRoom();
     },[myAllChatRoom]);
@@ -97,7 +111,11 @@ export default function CrewChatList() {
                                         <S.ChatMemNumbers>{room.chatMemberNumbers}</S.ChatMemNumbers>
                                     </S.ProfileContainer>
                                     {/* 입장버튼 */}
-                                    <S.EnterButton>입장하기</S.EnterButton>
+                                    <S.EnterButton
+                                        onClick={() => handleEnterRoom(room.roomId)}
+                                    >
+                                        입장하기
+                                    </S.EnterButton>
                                 </S.ChatRoomContainer>
                             ))
                         ):(

--- a/src/pages/CrewChat/Styles/CrewChat.styles.js
+++ b/src/pages/CrewChat/Styles/CrewChat.styles.js
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 import { FaTrashAlt } from "react-icons/fa";
 
-// ChattingList.jsx
+// ChatRoomList.jsx
 
 export const Panel = styled.div`
     width: 100%;
@@ -65,8 +65,17 @@ export const CrewProfile = styled.img`
     border: 1px solid #DEDFE7;
 `;
 
+export const TextContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+`;
+
+export const DetailContainer = styled.div`
+    display: flex;
+`;
+
 export const RoomName = styled.div`
-    width: 40%;
+    width: 120px;
     height: 20px;
     margin-top: 15px;
     white-space: nowrap;
@@ -78,6 +87,13 @@ export const MemNums = styled.div`
     height: 20px;
     margin: 15px 0px 0px 15px;
     color: #929292;
+`;
+
+export const RecentMsg = styled.div`
+    width: 120px;
+    color: #929292;
+    overflow: hidden;
+    text-overflow: ellipsis;
 `;
 
 export const NewName = styled.input`

--- a/src/pages/CrewChat/components/ChatRoomList.jsx
+++ b/src/pages/CrewChat/components/ChatRoomList.jsx
@@ -55,7 +55,19 @@ export default function ChatRoomList({onClose}) {
     const fetchChatRooms = async() => {
         try {
             const response = await ChatAPI.getMyChatRoom();
-            setChatRooms(response.data.data);
+            const resData = response.data.data;
+            const appendedMsgData = await Promise.all(
+                resData.map(async room => {
+                    try {
+                        const resMsg = await ChatAPI.getRoomRecentChat(room.roomId);
+                        // console.log(resMsg);
+                        return{...room, recentMsg: resMsg.data.data.message}
+                    } catch (error) {
+                        console.error(`${room.roomId} : 가장 최신 메시지 불러오기 실패`, error);
+                    }
+                })
+            );
+            setChatRooms(appendedMsgData);
         } catch (error) {
             console.error("채팅방 목록 불러오기 실패", error);
         }
@@ -102,8 +114,13 @@ export default function ChatRoomList({onClose}) {
                             onClick={() => goToChatRoom(room.roomId)}
                         >
                             <S.CrewProfile src={room.bannerImage}/>
-                            <S.RoomName>{room.name}</S.RoomName>
-                            <S.MemNums>{room.chatMemberNumbers}</S.MemNums>
+                            <S.TextContainer>
+                                <S.DetailContainer>
+                                    <S.RoomName>{room.name}</S.RoomName>
+                                    <S.MemNums>{room.chatMemberNumbers}</S.MemNums>
+                                </S.DetailContainer>
+                                <S.RecentMsg>{room.recentMsg}</S.RecentMsg>
+                            </S.TextContainer>
                         </S.RoomContainer>
                     ))}
                     {isChatRoomOpen && (

--- a/src/pages/CrewChat/components/CrewChatRoom.jsx
+++ b/src/pages/CrewChat/components/CrewChatRoom.jsx
@@ -50,7 +50,7 @@ export default function CrewChatRoom({chatRoom, fetchChatRooms,onClose}) {
     // 채팅방 입장
     useEffect(() => {
         if (stompClient) {
-            enterChatRoom();
+            enterChatRoom(roomId);
         }
     }, [stompClient]);
 

--- a/src/pages/CrewChat/components/CrewChatRoom.jsx
+++ b/src/pages/CrewChat/components/CrewChatRoom.jsx
@@ -43,7 +43,7 @@ export default function CrewChatRoom({chatRoom, fetchChatRooms,onClose}) {
     // 웹소켓 연결 (채팅방 연결 및 구독)
     useEffect(() => {
         async function JoinChat() {
-            await connect();
+            await connect(roomId);
         }
         JoinChat();
     },[]);

--- a/src/pages/CrewHome/CrewHome.jsx
+++ b/src/pages/CrewHome/CrewHome.jsx
@@ -74,7 +74,7 @@ export default function CrewHome() {
                     currentNum: resCrewData.memberCount,
                     crewIntro: resCrewData.description
                 });
-                console.log(resCrewData);
+                // console.log(resCrewData);
             } catch (error) {
                 console.error("크루 읽기 실패", error);
             }


### PR DESCRIPTION
## 📌 채팅방 목록 페이지
- 웹소켓 입장 기능 구현

## 📌 팝업 채팅창
- 각 채팅방의 최근 메시지를 채팅창 목록에서 볼 수 있도록 구현

## 🎨 UI/UX 개선
- 최근 메시지가 너무 길 경우 말줄임 표시

## ✅ 테스트 항목
- [x] 입장하기 버튼 클릭 후 팝업 채팅창 목록 변경되는지
- [ ] 입장하기 버튼 클릭 후 채팅방 목록 페이지 변경되는지
- [ ] 각 채팅방 최근 메시지가 제대로 뜨는지

2,3번 항목은 > 지금 로그인이 안되어서... 나중에 테스트 해보겠습니다!

## 🔍 추가 고려사항
입장하기 버튼 웹소켓 연결을 하긴 했는데 버튼을 두 번 둘러야지 입장 처리됩니다... ( 한 번 누르면 웹소켓 연결하라 뜨고 두 번째에 누르면 웹소켓 연결 상태이므로 이 때 입장처리가 실행되더라구요 )

## 💻 참고용 영상
.