### PR TITLE
feat: 공지 투표 기능 종류 설정(general, attendance)

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -100,6 +100,12 @@ export const noticeAPI = {
     updateNotice: (crewId, noticeId,noticeData)=> api.put(`/crews/${crewId}/notices/${noticeId}`, noticeData),
     deleteNotice: (crewId, noticeId) => api.delete(`/crews/${crewId}/notices/${noticeId}`),
     noticePinToggle: (crewId, noticeId) => api.patch(`/crews/${crewId}/notices/${noticeId}/pin-toggle`),
+    // 투표 API
+    selectVote: (crewId, noticeId, voteId, voteStatus) =>
+        api.post(`/crews/${crewId}/notices/${noticeId}/vote/${voteId}`, voteStatus),
+    reSelectVote: (crewId, noticeId, voteId, voteStatus) =>
+        api.put(`/crews/${crewId}/notices/${noticeId}/vote/${voteId}`, voteStatus),
+
 };
 
 export const crewAPI = {

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -2,7 +2,6 @@ import { useEffect, useState } from "react";
 import * as S from "../Styles/Notice.styles";
 import { noticeAPI } from "../../../api";
 import { useNavigate, useParams } from "react-router-dom";
-import { useNotices } from "../NoticeProvider";
 
 export default function AddNotice() {
     const { crewId } = useParams(); //crewId 받기
@@ -12,14 +11,13 @@ export default function AddNotice() {
     const [voteInfo, setVoteInfo] = useState({});
     const [notice, setNotice] = useState("");
 
-    // voteInfo 직접 수정 기능 만들기
     useEffect(()=>{
         const initialVoteInfo = {
-            title: "정모 참여 여부 투표",
+            title: "투표명 설정해주세요",
             selectList: isGeneral ? ["찬성", "반대"] : ["참석", "미참석"]
         }
         setVoteInfo(initialVoteInfo);
-    },[]);
+    },[isGeneral]);
 
     const handleTitle = (e) => setVoteInfo((prev)=>({...prev, title: e.target.value}));
     const handleNotice = (e) => setNotice(e.target.value);
@@ -64,6 +62,19 @@ export default function AddNotice() {
                         onChange={handleNotice}
                     />
                     <S.VoteContainer>
+                        {isEnabled && <S.TopContainer>
+                            {isGeneral ? (
+                                <div style={{display: "flex"}}>
+                                    <S.VoteTypeText>* 찬반투표 *</S.VoteTypeText>
+                                    <S.ChangeVoteType onClick={()=>setIsGenral(!isGeneral)}/>
+                                </div>
+                            ):(
+                                <div style={{display: "flex"}}>
+                                    <S.VoteTypeText>* 참석여부투표 *</S.VoteTypeText>
+                                    <S.ChangeVoteType onClick={()=>setIsGenral(!isGeneral)}/>
+                                </div>
+                            )}
+                        </S.TopContainer>}
                         <S.VoteBox shouldHide={!isEnabled}>
                             <S.VoteTitle
                                 value={voteInfo.title}

--- a/src/pages/CrewNotice/Components/AddNotice.jsx
+++ b/src/pages/CrewNotice/Components/AddNotice.jsx
@@ -7,8 +7,8 @@ import { useNotices } from "../NoticeProvider";
 export default function AddNotice() {
     const { crewId } = useParams(); //crewId 받기
     const navigate = useNavigate();
-    const { noticeList, setNoticeList } = useNotices();
     const [isEnabled, setIsEnabled] = useState(true);
+    const [isGeneral, setIsGenral] = useState(true);
     const [voteInfo, setVoteInfo] = useState({});
     const [notice, setNotice] = useState("");
 
@@ -16,7 +16,7 @@ export default function AddNotice() {
     useEffect(()=>{
         const initialVoteInfo = {
             title: "정모 참여 여부 투표",
-            selectList: ["참여", "미참여"]
+            selectList: isGeneral ? ["찬성", "반대"] : ["참석", "미참석"]
         }
         setVoteInfo(initialVoteInfo);
     },[]);
@@ -30,6 +30,7 @@ export default function AddNotice() {
                 content: notice,
                 vote: {
                     isEnabled: isEnabled,
+                    voteType: isGeneral ? "GENERAL" : "ATTENDANCE",
                     title: voteInfo.title,
                 }
             }:{

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -13,6 +13,18 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
     const handlePin = (id)=> togglePin(id);
     const handleMenu = (id) => toggleMenu(id);
 
+    const handleVote = async(noticeId, voteId, status) => {
+        try {
+            const submitStatus = {
+                voteStatus: status
+            }
+            const response = await noticeAPI.selectVote(crewId, noticeId, voteId, submitStatus);
+            // console.log(response);
+        } catch (error) {
+            console.error("투표 실패", error);
+        }
+    }
+
     const handleUpdate = ({notice})=>{
         navigate(`/crews/${crewId}/updateNotice/${notice.id}`, {
             state: {noticeData: notice,  mode: "update"}
@@ -23,7 +35,8 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
         try {
             if (window.confirm("정말로 삭제하시겠습니까?")) {
                 await noticeAPI.deleteNotice(crewId, noticeId);
-                setNoticeList(currentnoticeList => currentnoticeList.filter(notice => notice.id !== noticeId));
+                setNoticeList(currentnoticeList =>
+                    currentnoticeList.filter(notice => notice.id !== noticeId));
                 alert("공지가 삭제되었습니다");
             }
         } catch (error) {
@@ -32,8 +45,10 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
     }
 
     useEffect(() => {
+        // console.log(noticeList);
         function handleClickOutside(e) {
-            if (noticeList.some((notice, index) => notice.isOpenedMenu && menuRefs.current[index] && !menuRefs.current[index].contains(e.target))) {
+            if (noticeList.some((notice, index) => notice.isOpenedMenu &&
+            menuRefs.current[index] && !menuRefs.current[index].contains(e.target))) {
                 setNoticeList(noticeList.map(notice => ({...notice, isOpenedMenu: false})));
             }   
         }
@@ -48,7 +63,9 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
             const response = await noticeAPI.readNotice(crewId,noticeId);
             const updateNoticeData = response.data.data;
             setNoticeList(noticeList.map(notice => 
-                notice.id === noticeId ? ({...notice, ...updateNoticeData, showDetail: !notice.showDetail}) : notice,
+                notice.id === noticeId ? ({
+                    ...notice, ...updateNoticeData, showDetail: !notice.showDetail
+                }) : notice,
             ));
         } catch (error) {
             console.log("통신 실패 : ", error);
@@ -115,13 +132,41 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
                                             <S.VoteTitleText>{notice.vote?.title}</S.VoteTitleText>
                                             {notice.vote?.voteType === "GENERAL" ? (
                                                 <S.SelectBox>
-                                                    <S.SelectList userVote>찬성</S.SelectList>
-                                                    <S.SelectList userVote>반대</S.SelectList>
+                                                    <S.SelectList
+                                                        userVote
+                                                        onClick={() => handleVote(
+                                                            notice.noticeId, notice.vote?.voteId, "POSITIVE"
+                                                        )}
+                                                    >
+                                                        찬성
+                                                    </S.SelectList>
+                                                    <S.SelectList
+                                                        userVote
+                                                        onClick={() => handleVote(
+                                                            notice.noticeId, notice.vote?.voteId, "NEGATIVE"
+                                                        )}
+                                                    >
+                                                        반대
+                                                    </S.SelectList>
                                                 </S.SelectBox>
                                             ):(
                                                 <S.SelectBox>
-                                                    <S.SelectList userVote>참석</S.SelectList>
-                                                    <S.SelectList userVote>미참석</S.SelectList>
+                                                    <S.SelectList
+                                                        userVote
+                                                        onClick={() => handleVote(
+                                                            notice.noticeId, notice.vote?.voteId, "POSITIVE"
+                                                        )}
+                                                    >
+                                                        참석
+                                                    </S.SelectList>
+                                                    <S.SelectList
+                                                        userVote
+                                                        onClick={() => handleVote(
+                                                            notice.noticeId, notice.vote?.voteId, "NEGATIVE"
+                                                        )}
+                                                    >
+                                                        미참석
+                                                    </S.SelectList>
                                                 </S.SelectBox>
                                             )}
                                         </S.VoteBox>

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -46,8 +46,9 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
     const handleShowDetail = async (noticeId) => {
         try {
             const response = await noticeAPI.readNotice(crewId,noticeId);
+            const updateNoticeData = response.data.data;
             setNoticeList(noticeList.map(notice => 
-                notice.id === noticeId ? ({...notice, showDetail: !notice.showDetail}) : notice,
+                notice.id === noticeId ? ({...notice, ...updateNoticeData, showDetail: !notice.showDetail}) : notice,
             ));
         } catch (error) {
             console.log("통신 실패 : ", error);

--- a/src/pages/CrewNotice/Components/NoticeList.jsx
+++ b/src/pages/CrewNotice/Components/NoticeList.jsx
@@ -112,11 +112,18 @@ export default function NoticeList({noticeList, togglePin, toggleMenu, setNotice
                                 <Vote>
                                     <S.VoteContainer style={{margin: "0"}}>
                                         <S.VoteBox style={{fontSize: "small"}}>
-                                            <S.VoteTitleText>정모 참여 투표</S.VoteTitleText>
-                                            <S.SelectBox>
-                                                <S.SelectList userVote>참여</S.SelectList>
-                                                <S.SelectList userVote>미참여</S.SelectList>
-                                            </S.SelectBox>
+                                            <S.VoteTitleText>{notice.vote?.title}</S.VoteTitleText>
+                                            {notice.vote?.voteType === "GENERAL" ? (
+                                                <S.SelectBox>
+                                                    <S.SelectList userVote>찬성</S.SelectList>
+                                                    <S.SelectList userVote>반대</S.SelectList>
+                                                </S.SelectBox>
+                                            ):(
+                                                <S.SelectBox>
+                                                    <S.SelectList userVote>참석</S.SelectList>
+                                                    <S.SelectList userVote>미참석</S.SelectList>
+                                                </S.SelectBox>
+                                            )}
                                         </S.VoteBox>
                                     </S.VoteContainer>
                                 </Vote>

--- a/src/pages/CrewNotice/Components/UpdateNotice.jsx
+++ b/src/pages/CrewNotice/Components/UpdateNotice.jsx
@@ -50,8 +50,8 @@ export default function UpdateNotice() {
                     isEnabled: isEnabled,
                 }
             }
-            console.log("noticeId",noticeId);
-            console.log("noticeData",noticeData);
+            // console.log("noticeId",noticeId);
+            // console.log("noticeData",noticeData);
             await noticeAPI.updateNotice(crewId, noticeId, noticeData);
             alert("공지가 수정되었습니다");
             navigate(`/crews/${crewId}/crewNotice`);

--- a/src/pages/CrewNotice/Components/UpdateNotice.jsx
+++ b/src/pages/CrewNotice/Components/UpdateNotice.jsx
@@ -7,18 +7,18 @@ export default function UpdateNotice() {
     const location = useLocation();
     const navigate = useNavigate();
     const { crewId } = useParams();
+    const NoticeData = location.state.noticeData;
 
-    // const [isDeleted, setIsDeleted] = useState(false);
     const [voteInfo, setVoteInfo] = useState({});
     const [notice, setNotice] = useState('');
-    const [isEnabled, setIsEnabled] = useState(location.state.noticeData.isEnabled);
+    const [isEnabled, setIsEnabled] = useState(NoticeData.vote.isEnabled);
+    const [isGeneral, setIsGenral] = useState(NoticeData.vote.voteType === "GENERAL");
     
-    console.log(notice);
     useEffect(() => {
         // location.state가 정의되어 있고, 그 안에 noticeData 객체가 존재하는지를 확인하여 상태 설정
-        if (location.state && location.state.noticeData) {
-            console.log(location.state.noticeData);
-            setNotice(location.state.noticeData.content);
+        if (location.state && NoticeData) {
+            // console.log(NoticeData);
+            setNotice(NoticeData.content);
         }
         // // 다른 notice 선택으로 인해 location.state변하기 때문에 의존성 배열로 설정
     }, [location.state]);
@@ -26,22 +26,23 @@ export default function UpdateNotice() {
     // voteInfo 초기화
     useEffect(()=>{
         const initialVoteInfo = {
-            title: "정모 참여 여부 투표",
-            selectList: ["참여", "미참여"]
+            title: NoticeData.vote.title,
+            selectList: isGeneral ? ["찬성", "반대"] : ["참석", "미참석"]
         }
         setVoteInfo(initialVoteInfo);
-    },[]);
+    },[isGeneral]);
 
     const handleNotice = (e) => setNotice(e.target.value);
     const handleTitle = (e) => setVoteInfo((prev)=>({...prev, title: e.target.value}));
 
     const handleSubmit = async ()=>{
         try {
-            const noticeId = location.state.noticeData.id;
+            const noticeId = NoticeData.noticeId;
             const noticeData = isEnabled ? {
                 content: notice,
                 vote: {
                     isEnabled: isEnabled,
+                    voteType: isGeneral ? "GENERAL" : "ATTENDANCE",
                     title: voteInfo.title,
                 }
             }:{
@@ -70,6 +71,19 @@ export default function UpdateNotice() {
                         onChange={handleNotice}
                     ></S.InputText>
                     <S.VoteContainer>
+                        {isEnabled && <S.TopContainer>
+                            {isGeneral ? (
+                                <div style={{display: "flex"}}>
+                                    <S.VoteTypeText>* 찬반투표 *</S.VoteTypeText>
+                                    <S.ChangeVoteType onClick={()=>setIsGenral(!isGeneral)}/>
+                                </div>
+                            ):(
+                                <div style={{display: "flex"}}>
+                                    <S.VoteTypeText>* 참석여부투표 *</S.VoteTypeText>
+                                    <S.ChangeVoteType onClick={()=>setIsGenral(!isGeneral)}/>
+                                </div>
+                            )}
+                        </S.TopContainer>}
                         <S.VoteBox shouldHide={!isEnabled}>
                             <S.VoteTitle
                                 value={voteInfo.title}

--- a/src/pages/CrewNotice/Components/UpdateNotice.jsx
+++ b/src/pages/CrewNotice/Components/UpdateNotice.jsx
@@ -23,7 +23,6 @@ export default function UpdateNotice() {
         // // 다른 notice 선택으로 인해 location.state변하기 때문에 의존성 배열로 설정
     }, [location.state]);
     
-    // voteInfo 초기화
     useEffect(()=>{
         const initialVoteInfo = {
             title: NoticeData.vote.title,

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -72,7 +72,7 @@ export default function CrewNotice() {
 
             const isAdmin = Array.isArray(members) &&
                 members.some(member => member.nickname === userInfo.nickname &&
-                    (member.role === 'LEADER' || member.role === 'SUB_LEADER')
+                    (member.role === 'LEADER' || member.role === 'ADMIN')
                 );
 
             setIsManager(isAdmin);

--- a/src/pages/CrewNotice/CrewNotice.jsx
+++ b/src/pages/CrewNotice/CrewNotice.jsx
@@ -163,8 +163,9 @@ export default function CrewNotice() {
     return(
         <Wrapper>
             <CrewChat/>
-            {/* userid 받아서 관리자만 보이도록 수정해야 함 */}
-            <AddNoticeButton onClick={linktoAddNotice} >+ 공지추가</AddNoticeButton>
+            {isManager &&
+                <AddNoticeButton onClick={linktoAddNotice} >+ 공지추가</AddNoticeButton>
+            }
             {/* 무한스크롤 적용해야 함 */}
             <NoticeContainer>
                 {noticeList.length > 0 ? (

--- a/src/pages/CrewNotice/NoticeProvider.jsx
+++ b/src/pages/CrewNotice/NoticeProvider.jsx
@@ -3,17 +3,9 @@ import React, { createContext, useContext, useState } from 'react';
 const NoticeContext = createContext(null);
 export const useNotices = () => useContext(NoticeContext);
 
-const initialNoticeList = [
-    { id: 1, content: "첫 번째 공지사항 내용입니다.\ndd", date: "2024.12.10 (화)", time: "12:00", 
-        isPinned: false, isOpenedMenu: false, isEnabled: false },
-    { id: 2, content: "두 번째 공지사항 내용입니다.", date: "2024.12.10 (화)", time: "13:00",
-         isPinned: false, isOpenedMenu: false, isEnabled: false },
-    { id: 3, content: "세 번째 공지사항 내용입니다.", date: "2024.12.12 (목)", time: "03:00",
-         isPinned: false, isOpenedMenu: false, isEnabled: true }
-];
 
 export const NoticeProvider = ({ children }) => {
-    const [noticeList, setNoticeList] = useState(initialNoticeList);
+    const [noticeList, setNoticeList] = useState([]);
 
     return (
         <NoticeContext.Provider value={{ noticeList, setNoticeList }}>

--- a/src/pages/CrewNotice/Styles/Notice.styles.js
+++ b/src/pages/CrewNotice/Styles/Notice.styles.js
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { FaArrowsRotate } from "react-icons/fa6";
 
 export const Wrapper = styled.div`
     display: flex;
@@ -8,6 +9,7 @@ export const Wrapper = styled.div`
     margin-top: 30px;
     margin-bottom: 100px;
 `;
+
 export const Container = styled.div`
     display: flex;
     flex-direction: column;
@@ -20,16 +22,36 @@ export const Container = styled.div`
     border: 1px solid #DEDFE7;
     border-radius: 15px;
 `;
+
 export const MainContainer = styled.div`
     display: flex;
-    
+    height: 300px;
 `;
+
 export const VoteContainer = styled.div`
     margin: 50px 30px;
     display: flex;
     flex-direction: column;
     align-items: center;
-    `;
+    position: relative;
+`;
+
+export const TopContainer = styled.div`
+`;
+
+export const VoteTypeText = styled.div`
+    margin-bottom: 5px;
+`;
+
+export const ChangeVoteType = styled(FaArrowsRotate)`
+    color: #352EAE;
+    cursor: pointer;
+
+    position: absolute;
+    top: 1px;
+    right: 10px;
+`;
+
 export const VoteBox = styled.div`
     width: 200px;
     margin-bottom: 20px;
@@ -39,14 +61,18 @@ export const VoteBox = styled.div`
     border-radius: 5px;
     display: ${props => props.shouldHide ? 'none' : 'inline-block'};
 `;
+
 export const VoteTitle = styled.input`
     margin: 10px 0px 0px 10px;
 `;
+
 export const VoteTitleText = styled.div`
     margin: 10px 0px 0px 10px;
 `;
-export const SelectBox = styled.div`
-`;
+
+
+export const SelectBox = styled.div``;
+
 export const SelectList = styled.li`
     margin: 10px;
     padding: 5px;
@@ -60,8 +86,9 @@ export const SelectList = styled.li`
         background-color: ${props => props.userVote ? '#D4E3FB' : 'transparent'};
     }
 `;
-export const ButtonContainer = styled.div`
-`;
+
+export const ButtonContainer = styled.div``;
+
 export const VoteButton = styled.button`
     width: 200px;
     padding: 10px;
@@ -75,6 +102,7 @@ export const VoteButton = styled.button`
         cursor: pointer;
     }
 `;
+
 export const InputText = styled.textarea`
     margin: 40px 0px 20px 40px;
     padding: 20px;
@@ -85,10 +113,12 @@ export const InputText = styled.textarea`
     border: none;
     border-radius: 15px;
 `;
+
 export const SubContainer = styled.div`
     display: flex;
     justify-content: center;
 `;
+
 export const PostNotice = styled.button`
     padding: 10px;
     width: 15%;

--- a/src/router/Router.jsx
+++ b/src/router/Router.jsx
@@ -35,7 +35,7 @@ const Router = () => {
                 <Route path="/crews/:crewId" element={<CrewMain />}>
                     <Route path="crewHome" element={<CrewHome />} />
                     <Route path="crewNotice" element={<NoticeProvider><CrewNotice /></NoticeProvider>} />
-                    <Route path="addNotice" element={<NoticeProvider><AddNotice /></NoticeProvider>} />
+                    <Route path="addNotice" element={<AddNotice />} />
                     <Route path="updateNotice/:noticeId" element={<UpdateNotice />} />
                     <Route path="crewActivity" element={<Activities />} />
                     <Route path="archives/:archiveId" element={<Details />} />


### PR DESCRIPTION
## 📌 변경사항
- 공지 생성 시 투표 종류 선택 ( GENERAL / ATTENDANCE )
- 공지 수정 시 기존 투표명, 종류 데이터도 같이 설정
- 공지 목록 볼 수 있는 페이지에서 공지 클릭 시 설정한 투표 데이터( 투표명, 선택리스트? ) 설정
- 공지 추가 버튼 -> 리더/관리자만 볼 수 있도록 변경
- 특정 공지 투표 api -> 500에러( userId없이 투표가 되는 상태라서 뜨는 것 같습니다. 백 선배님과 조율 후 다시 pr 올리겠습니다 )

## 🎨 UI/UX 개선
- 투표 종류 선택 변경을 위한 화살표 아이콘 추가
- 현재 선택한 투표 종류가 무엇인지 표시를 위한 텍스트 설정( 찬반투표 / 참석여부 투표 )

## ✅ 테스트 항목
- [x] 공지 생성 시 설정한 투표명 제대로 뜨는지 + 설정한 투표 종류에 따른 선택리스트 보이는지
- [x] 공지 수정 시 재설정한 투표명 제대로 뜨는지 + 투표 종류 재설정하면 적용 잘되는지
- [x] 공지 추가 버튼 멤버에게 안보이고 리더에겐 보이는지
- [x] => 관리자에게도 보이는지

## 🔍 추가 고려사항
공지 투표 api가 엔드포인트가 현재 `/crews/{crewId}/notices/{noticeId}/vote/{voteId}` 이렇게 되는 것을 보아 각 유저의 투표 정보를 전송할 수 없는 것 같습니다. 그래서 500에러가 뜨는 것이 아닐까요?  백 선배님과 이야기 나눠보고 조율 후 다시 구현하여 pr 올리겠습니다!

💻 참고용 영상

https://github.com/user-attachments/assets/0141ecde-3c7f-4f2b-ab82-58774883852e


